### PR TITLE
Add GitHub Actions CI (Linux + Windows/MSVC) with README badges

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,72 @@
+#          Copyright Rein Halbersma 2014-2025.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.cxx }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cc: gcc-11
+            cxx: g++-11
+            gcc_version: 11
+          - cc: gcc-12
+            cxx: g++-12
+            gcc_version: 12
+          - cc: gcc-13
+            cxx: g++-13
+            gcc_version: 13
+          - cc: clang-15
+            cxx: clang++-15
+            clang_version: 15
+          - cc: clang-16
+            cxx: clang++-16
+            clang_version: 16
+          - cc: clang-17
+            cxx: clang++-17
+            clang_version: 17
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GCC ${{ matrix.gcc_version }}
+        if: matrix.gcc_version
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.cxx }}
+
+      - name: Install Clang ${{ matrix.clang_version }}
+        if: matrix.clang_version
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{ matrix.clang_version }}
+
+      - name: Install Boost.Test
+        run: sudo apt-get install -y libboost-test-dev
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_C_COMPILER=${{ matrix.cc }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+
+      - name: Build
+        run: cmake --build build -v
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,52 @@
+#          Copyright Rein Halbersma 2014-2025.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+name: Windows
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: MSVC ${{ matrix.vs }} (${{ matrix.arch }})
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - vs: 2022
+            generator: "Visual Studio 17 2022"
+            arch: x64
+            triplet: x64-windows
+          - vs: 2022
+            generator: "Visual Studio 17 2022"
+            arch: Win32
+            triplet: x86-windows
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Boost.Test
+        shell: pwsh
+        run: vcpkg install boost-test:${{ matrix.triplet }}
+
+      - name: Configure
+        shell: pwsh
+        run: >
+          cmake -S . -B build
+          -G "${{ matrix.generator }}" -A ${{ matrix.arch }}
+          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build
+        shell: pwsh
+        run: cmake --build build --config Release -v
+
+      - name: Test
+        shell: pwsh
+        run: ctest --test-dir build -C Release --output-on-failure

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Standard](https://img.shields.io/badge/c%2B%2B-20-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)
 [![License](https://img.shields.io/badge/license-Boost-blue.svg)](https://opensource.org/licenses/BSL-1.0)
 [![Lines of Code](https://tokei.rs/b1/github/rhalbersma/xstd?category=code)](https://github.com/rhalbersma/xstd)
+[![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml)
 
 | Header                   | Additions          | Description | Reference |
 | :-----                   | :--------          | :---------- | :-------- |
@@ -17,11 +18,11 @@
 
 These header-only libraries are continuously being tested with the following conforming [C++20](http://www.open-std.org/jtc1/sc22/wg21/prot/14882fdis/n4860.pdf) compilers:
 
-| Platform | Compiler       | Versions       | Build |
-| :------- | :-------       | :-------       | :---- |
-| Linux    | GCC            | 11, 12, 13-SVN | CI currently being ported to GitHub Actions |
-| Linux    | Clang          | 15, 16, 17-SVN | CI currently being ported to GitHub Actions |
-| Windows  | Visual Studio  | 2019, 2022     | CI currently being ported to GitHub Actions |
+| Platform | Compiler       | Versions   | Build |
+| :------- | :-------       | :-------   | :---- |
+| Linux    | GCC            | 11, 12, 13 | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
+| Linux    | Clang          | 15, 16, 17 | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
+| Windows  | Visual Studio  | 2019, 2022 | CI currently being ported to GitHub Actions |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/badge/license-Boost-blue.svg)](https://opensource.org/licenses/BSL-1.0)
 [![Lines of Code](https://tokei.rs/b1/github/rhalbersma/xstd?category=code)](https://github.com/rhalbersma/xstd)
 [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml)
+[![Windows](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml)
 
 | Header                   | Additions          | Description | Reference |
 | :-----                   | :--------          | :---------- | :-------- |
@@ -22,7 +23,7 @@ These header-only libraries are continuously being tested with the following con
 | :------- | :-------       | :-------   | :---- |
 | Linux    | GCC            | 11, 12, 13 | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
 | Linux    | Clang          | 15, 16, 17 | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
-| Windows  | Visual Studio  | 2019, 2022 | CI currently being ported to GitHub Actions |
+| Windows  | Visual Studio  | 2022       | [![Windows](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml) |
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/linux.yml`: cmake + ctest pipeline on Ubuntu 22.04 across GCC 11/12/13 and Clang 15/16/17
- Add green Linux CI badges to README, covering all supported GCC/Clang versions, and drop the untested `-SVN` trunk compiler versions from the compatibility table
- Add `.github/workflows/windows.yml`: MSVC support via `windows-2022` (VS 2022 / MSVC v143) across x64 and Win32, using vcpkg for Boost.Test, with a matching green badge

## Notes
- Windows Server 2019 GitHub-hosted runners have been retired, so the Windows matrix targets `windows-2022` only; the README compiler table was updated to drop VS 2019 accordingly.

## Test plan
- [ ] Confirm the `Linux` workflow passes for all GCC/Clang matrix legs
- [ ] Confirm the `Windows` workflow passes for both x64 and Win32
- [ ] Confirm the README badges render green once CI runs on `master`


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_