### PR TITLE
Expand CI matrix to latest stable + trunk/preview compilers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,47 +14,79 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.cxx }}
+    name: ${{ matrix.family }} ${{ matrix.label }}
     runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.trunk }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - cc: gcc-11
-            cxx: g++-11
-            gcc_version: 11
-          - cc: gcc-12
-            cxx: g++-12
-            gcc_version: 12
-          - cc: gcc-13
-            cxx: g++-13
-            gcc_version: 13
-          - cc: clang-15
-            cxx: clang++-15
-            clang_version: 15
-          - cc: clang-16
-            cxx: clang++-16
-            clang_version: 16
-          - cc: clang-17
-            cxx: clang++-17
-            clang_version: 17
+          - family: gcc
+            label: "15"
+            version: 15
+            cc: gcc-15
+            cxx: g++-15
+            trunk: false
+          - family: gcc
+            label: "16"
+            version: 16
+            cc: gcc-16
+            cxx: g++-16
+            trunk: false
+          - family: gcc
+            label: 17-SVN
+            version: 17
+            cc: gcc-17
+            cxx: g++-17
+            trunk: true
+          - family: clang
+            label: "21"
+            version: 21
+            cc: clang-21
+            cxx: clang++-21
+            trunk: false
+          - family: clang
+            label: "22"
+            version: 22
+            cc: clang-22
+            cxx: clang++-22
+            trunk: false
+          - family: clang
+            label: 23-SVN
+            version: 23
+            cc: clang-23
+            cxx: clang++-23
+            trunk: true
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install GCC ${{ matrix.gcc_version }}
-        if: matrix.gcc_version
+      - name: Install GCC ${{ matrix.version }} (stable)
+        if: matrix.family == 'gcc' && !matrix.trunk
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.cxx }}
 
-      - name: Install Clang ${{ matrix.clang_version }}
-        if: matrix.clang_version
+      # Best-effort: installs Jonathan Wakely's binary snapshot of GCC trunk
+      # (see https://jwakely.github.io/pkg-gcc-latest/). Not an official GCC
+      # release, so this leg is allowed to fail (see continue-on-error above).
+      - name: Install GCC trunk snapshot
+        if: matrix.family == 'gcc' && matrix.trunk
+        run: |
+          wget -q http://kayari.org/gcc-latest/gcc-latest.deb
+          sudo dpkg -i gcc-latest.deb || sudo apt-get install -f -y
+          sudo ln -sf /opt/gcc-latest/bin/gcc /usr/bin/${{ matrix.cc }}
+          sudo ln -sf /opt/gcc-latest/bin/g++ /usr/bin/${{ matrix.cxx }}
+          ${{ matrix.cc }} --version
+          ${{ matrix.cxx }} --version
+
+      - name: Install Clang ${{ matrix.version }}
+        if: matrix.family == 'clang'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh ${{ matrix.clang_version }}
+          sudo ./llvm.sh ${{ matrix.version }}
 
       - name: Install Boost.Test
         run: sudo apt-get install -y libboost-test-dev

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,32 +15,82 @@ on:
 jobs:
   build:
     name: MSVC ${{ matrix.vs }} (${{ matrix.arch }})
-    runs-on: windows-2022
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.preview }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - vs: 2022
+            os: windows-2022
             generator: "Visual Studio 17 2022"
             arch: x64
             triplet: x64-windows
+            preview: false
           - vs: 2022
+            os: windows-2022
             generator: "Visual Studio 17 2022"
             arch: Win32
             triplet: x86-windows
+            preview: false
+          - vs: 2026
+            os: windows-2025
+            generator: "Visual Studio 18 2026"
+            arch: x64
+            triplet: x64-windows
+            preview: false
+          - vs: 2026
+            os: windows-2025
+            generator: "Visual Studio 18 2026"
+            arch: Win32
+            triplet: x86-windows
+            preview: false
+          - vs: 2026-Preview
+            os: windows-2025
+            generator: "Visual Studio 18 2026"
+            arch: x64
+            triplet: x64-windows
+            preview: true
 
     steps:
       - uses: actions/checkout@v4
+
+      # Best-effort: installs the VS 2026 Insiders channel side-by-side with
+      # the pre-installed Stable channel, to get at the MSVC Preview toolset.
+      # This is not an officially supported CI configuration, so this leg is
+      # allowed to fail (see continue-on-error above).
+      - name: Install MSVC Preview channel
+        if: matrix.preview
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://aka.ms/vs/18/insiders/channel -OutFile VisualStudio.chman
+          Invoke-WebRequest -Uri https://aka.ms/vs/18/insiders/vs_buildtools.exe -OutFile vs_buildtools.exe
+          ./vs_buildtools.exe --quiet --wait --norestart --nocache `
+            --channelUri VisualStudio.chman `
+            --installChannelUri VisualStudio.chman `
+            --add Microsoft.VisualStudio.Workload.VCTools `
+            --includeRecommended
 
       - name: Install Boost.Test
         shell: pwsh
         run: vcpkg install boost-test:${{ matrix.triplet }}
 
       - name: Configure
+        if: "!matrix.preview"
         shell: pwsh
         run: >
           cmake -S . -B build
           -G "${{ matrix.generator }}" -A ${{ matrix.arch }}
+          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Configure (preview toolset)
+        if: matrix.preview
+        shell: pwsh
+        run: >
+          cmake -S . -B build
+          -G "${{ matrix.generator }}" -A ${{ matrix.arch }}
+          -T version=Preview
+          -DCMAKE_GENERATOR_INSTANCE="C:/Program Files/Microsoft Visual Studio/18/Insiders"
           "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@
 
 These header-only libraries are continuously being tested with the following conforming [C++20](http://www.open-std.org/jtc1/sc22/wg21/prot/14882fdis/n4860.pdf) compilers:
 
-| Platform | Compiler       | Versions   | Build |
-| :------- | :-------       | :-------   | :---- |
-| Linux    | GCC            | 11, 12, 13 | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
-| Linux    | Clang          | 15, 16, 17 | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
-| Windows  | Visual Studio  | 2022       | [![Windows](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml) |
+| Platform | Compiler       | Versions                 | Build |
+| :------- | :-------       | :-------                 | :---- |
+| Linux    | GCC            | 15, 16, 17-SVN            | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
+| Linux    | Clang          | 21, 22, 23-SVN            | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
+| Windows  | Visual Studio  | 2022, 2026, 2026-Preview  | [![Windows](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml) |
+
+The `-SVN` and `-Preview` legs track each compiler's trunk / preview channel and are allowed to fail without affecting the badges above.
 
 ## License
 


### PR DESCRIPTION
## Summary
- **Linux**: bump GCC to 15/16 (was 11/12/13) and Clang to 21/22 (was 15/16/17); add a GCC 17-SVN trunk leg (installed from Jonathan Wakely's [gcc-latest snapshot](https://jwakely.github.io/pkg-gcc-latest/)) and a Clang 23-SVN trunk leg (via `apt.llvm.org`/`llvm.sh`).
- **Windows**: add a VS 2026 (`windows-2025` runner) leg alongside the existing VS 2022 leg, plus a best-effort VS 2026 Preview/Insiders MSVC toolset leg.
- All trunk/preview legs run with `continue-on-error: true` so an experimental compiler failure can't turn the Linux/Windows badges red — they're best-effort coverage on top of the required stable versions.
- Updated the README compiler table (versions + a note explaining the trunk/preview legs).

## Notes
- The MSVC Preview leg installs the VS 2026 Insiders channel via `vs_buildtools.exe` and selects the Preview toolset with `-T version=Preview` / `CMAKE_GENERATOR_INSTANCE`. This isn't an officially documented CI configuration, so it may need adjustment once it's actually run — that's why it's allowed to fail independently.

## Test plan
- [ ] Confirm the Linux workflow's GCC 15/16 and Clang 21/22 legs pass
- [ ] Confirm the GCC 17-SVN and Clang 23-SVN trunk legs at least install and run (failures there are OK)
- [ ] Confirm the Windows VS 2022 and VS 2026 legs pass
- [ ] Confirm the VS 2026 Preview leg at least attempts installation (failure there is OK)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_