### PR TITLE
Fix Clang and GCC-trunk CI failures; reorder/clarify compiler table

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,6 +78,7 @@ jobs:
           sudo dpkg -i gcc-latest.deb || sudo apt-get install -f -y
           sudo ln -sf /opt/gcc-latest/bin/gcc /usr/bin/${{ matrix.cc }}
           sudo ln -sf /opt/gcc-latest/bin/g++ /usr/bin/${{ matrix.cxx }}
+          sudo ldconfig /opt/gcc-latest/lib64
           ${{ matrix.cc }} --version
           ${{ matrix.cxx }} --version
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ These header-only libraries are continuously being tested with the following con
 | :------- | :------- | :------------ | :------------- | :---------------- | :---- |
 | Linux    | GCC      | 15             | 16              | 17-SVN             | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
 | Linux    | Clang    | 21             | 22              | 23-SVN             | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
+| Windows  | Clang (`clang-cl`) | —    | 20.1.8 (bundled) | —               | [![Windows](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml) |
 | Windows  | MSVC     | 2022           | 2026            | 2026-Preview       | [![Windows](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml) |
-| Windows  | Clang (`clang-cl`) | —    | —               | bundled            | [![Windows](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml) |
 
 The `Trunk / Preview` column is allowed to fail independently and does not affect the badges above. The `clang-cl` leg tests Clang's diagnostics against the MSVC STL, using whichever LLVM version the Windows runner image bundles.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,7 +56,6 @@ set(cxx_compile_options_mbig_obj
     >
 )
 
-set(current_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(current_source_dir ${CMAKE_CURRENT_SOURCE_DIR}/src)
 file(GLOB_RECURSE targets RELATIVE ${current_source_dir} *.cpp)
 
@@ -72,11 +71,6 @@ foreach(t ${targets})
         ${target_id} PRIVATE
         ${CMAKE_PROJECT_NAME}
         Boost::unit_test_framework
-    )
-
-    target_include_directories(
-        ${target_id} PRIVATE
-        ${current_include_dir}
     )
 
     target_compile_definitions(


### PR DESCRIPTION
## Summary
- **`test/CMakeLists.txt`**: drop the dead include of `test/include` (the directory never existed and nothing includes from it). GCC silently ignores a missing `-I` directory, but Clang's `-Wmissing-include-dirs` (part of `-Weverything`) combined with `-Werror` turned it into a hard build failure on every Clang leg (21, 22, 23-SVN).
- **`linux.yml`**: add the `sudo ldconfig /opt/gcc-latest/lib64` step that the old `.travis.yml` had, so binaries built with the GCC trunk snapshot can find its newer `libstdc++` at runtime. Without it, `ctest` failed with `GLIBCXX_3.4.32' not found`.
- **`README.md`**: swap the Clang (`clang-cl`)/MSVC row order, and replace the "bundled" placeholder with the actual clang-cl version — **20.1.8**, confirmed against the current `windows-2022`/`windows-2025` runner-images documentation (both bundle the same LLVM version).

## Test plan
- [ ] Confirm the Linux workflow's Clang 21/22 legs (previously failing on `-Wmissing-include-dirs`) now pass
- [ ] Confirm the GCC 17-SVN trunk leg's `ctest` step (previously failing on `GLIBCXX_3.4.32`) now passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_