### PR TITLE
Drop stale p1682r3 reference from utility.hpp row

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | `<xstd/array.hpp>`       | `array_from_types` | Create an `array` from a type list | none |
 | `<xstd/cstdlib.hpp>`     | `abs` <br> `div` <br> `euclidean_div` <br> `floored_div` <br> `sign` | `constexpr std::abs(int)` <br> `constexpr std::div(int, int)` <br> Euclidean division <br> Floored division <br> `constexpr boost::math::sign` | [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) <br> [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) |
 | `<xstd/type_traits.hpp>` | `is_integral_constant` <br> `is_specialization_of` <br> `tagged_empty` <br> `optional_type` | Is a type an `integral_constant`? <br> Is a type a class template specialization? <br> A tagged empty type <br> An optional type | none <br> [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) <br> none <br> none |
-| `<xstd/utility.hpp>`     | `to_underlying`    | Preserve a compile-time constant through `std::to_underlying` (C++23) | [p1682r3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1682r3.html) (C++23) |
+| `<xstd/utility.hpp>`     | `to_underlying`    | Preserve a compile-time constant through `std::to_underlying` (C++23) | none |
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- The `<xstd/utility.hpp>` row in the Additions table still referenced p1682r3, but that paper only covers the plain `to_underlying(Enum)` overload that was already removed in #27. The remaining `integral_constant`-preserving overload has no standard equivalent, so the reference is now "none".


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_