### PR TITLE
Fix Linux CI: Clang 22 -Wc2y-extensions and GCC-trunk runtime linking

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,6 +79,7 @@ jobs:
           sudo ln -sf /opt/gcc-latest/bin/gcc /usr/bin/${{ matrix.cc }}
           sudo ln -sf /opt/gcc-latest/bin/g++ /usr/bin/${{ matrix.cxx }}
           sudo ldconfig /opt/gcc-latest/lib64
+          echo "LD_LIBRARY_PATH=/opt/gcc-latest/lib64:${LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
           ${{ matrix.cc }} --version
           ${{ matrix.cxx }} --version
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ set(cxx_compile_options_warnings
         -Wno-disabled-macro-expansion       # triggered by Boost.Test
         -Wno-global-constructors            # triggered by Boost.Test
         -Wno-used-but-marked-unused         # triggered by Boost.Test
+        -Wno-c2y-extensions                 # triggered by Boost.Test's use of __COUNTER__
     >
     $<$<CXX_COMPILER_ID:GNU>:
         -Wall


### PR DESCRIPTION
## Root cause
The Linux workflow was red on a **required** leg (`clang 22`, not just the allowed-to-fail trunk legs):

```
/home/runner/work/xstd/xstd/test/src/cstdlib.cpp:27:1: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
```

Boost.Test's `BOOST_AUTO_TEST_CASE` macro uses `__COUNTER__` internally (`BOOST_TEST_APPEND_UNIQUE_ID`) to generate unique per-test identifiers &mdash; a widely-supported vendor extension for decades, but not part of any ratified C++ standard. Clang 22 added a new diagnostic (`-Wc2y-extensions`) that flags it, and our `-Weverything -Werror -pedantic-errors` combo turned that into a hard build failure on every test target.

While investigating, I also found the allowed-to-fail `gcc 17-SVN` leg still failing its `ctest` step with `GLIBCXX_3.4.32' not found`, despite #26 having added an `ldconfig /opt/gcc-latest/lib64` step. The dynamic linker was still resolving `libstdc++.so.6` to the system copy at runtime rather than the GCC-trunk snapshot's newer one.

## Fix
- `test/CMakeLists.txt`: add `-Wno-c2y-extensions` to the Clang warnings block, following the existing pattern for other Boost.Test-triggered suppressions.
- `.github/workflows/linux.yml`: export `LD_LIBRARY_PATH=/opt/gcc-latest/lib64:...` via `$GITHUB_ENV` after installing the GCC trunk snapshot, so it takes precedence over the ldconfig cache at runtime regardless of cache ordering.

Verified locally against GCC 13.3 and Clang 18.1 (the `-Wno-c2y-extensions` flag is silently accepted on Clang 18 thanks to the existing `-Wno-unknown-warning-option`).

## Test plan
- [ ] Confirm the `clang 22` (and `clang 21`) legs pass
- [ ] Confirm the `gcc 17-SVN` leg's `ctest` step now passes (or at least gets past the GLIBCXX error)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_