### PR TITLE
Split CI into one workflow per compiler

### DIFF
--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -1,0 +1,55 @@
+#          Copyright Rein Halbersma 2014-2025.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+name: clang-cl
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    # clang-cl: Clang's MSVC-compatible driver, using the MSVC STL and linker
+    # rather than libc++. Exercises Clang's diagnostics (this repo builds
+    # with -Weverything -Werror under Clang) against the same code MSVC
+    # builds, using whichever LLVM the runner image bundles. Best-effort:
+    # see continue-on-error below.
+    name: clang-cl (${{ matrix.arch }})
+    runs-on: windows-2022
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - generator: "Visual Studio 17 2022"
+            toolset: "ClangCL,host=x64"
+            arch: x64
+            triplet: x64-windows
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Boost.Test
+        shell: pwsh
+        run: vcpkg install boost-test:${{ matrix.triplet }}
+
+      - name: Configure
+        shell: pwsh
+        run: >
+          cmake -S . -B build
+          -G "${{ matrix.generator }}" -A ${{ matrix.arch }}
+          -T ${{ matrix.toolset }}
+          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build
+        shell: pwsh
+        run: cmake --build build --config Release -v
+
+      - name: Test
+        shell: pwsh
+        run: ctest --test-dir build -C Release --output-on-failure

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,0 +1,62 @@
+#          Copyright Rein Halbersma 2014-2025.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+name: Clang
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Clang ${{ matrix.label }}
+    runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.trunk }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: "21"
+            version: 21
+            cc: clang-21
+            cxx: clang++-21
+            trunk: false
+          - label: "22"
+            version: 22
+            cc: clang-22
+            cxx: clang++-22
+            trunk: false
+          - label: 23-SVN
+            version: 23
+            cc: clang-23
+            cxx: clang++-23
+            trunk: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Clang ${{ matrix.version }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{ matrix.version }}
+
+      - name: Install Boost.Test
+        run: sudo apt-get install -y libboost-test-dev
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_C_COMPILER=${{ matrix.cc }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+
+      - name: Build
+        run: cmake --build build -v
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -3,7 +3,7 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
-name: Linux
+name: GCC
 
 on:
   push:
@@ -14,55 +14,34 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.family }} ${{ matrix.label }}
+    name: GCC ${{ matrix.label }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.trunk }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - family: gcc
-            label: "15"
+          - label: "15"
             version: 15
             cc: gcc-15
             cxx: g++-15
             trunk: false
-          - family: gcc
-            label: "16"
+          - label: "16"
             version: 16
             cc: gcc-16
             cxx: g++-16
             trunk: false
-          - family: gcc
-            label: 17-SVN
+          - label: 17-SVN
             version: 17
             cc: gcc-17
             cxx: g++-17
-            trunk: true
-          - family: clang
-            label: "21"
-            version: 21
-            cc: clang-21
-            cxx: clang++-21
-            trunk: false
-          - family: clang
-            label: "22"
-            version: 22
-            cc: clang-22
-            cxx: clang++-22
-            trunk: false
-          - family: clang
-            label: 23-SVN
-            version: 23
-            cc: clang-23
-            cxx: clang++-23
             trunk: true
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install GCC ${{ matrix.version }} (stable)
-        if: matrix.family == 'gcc' && !matrix.trunk
+        if: "!matrix.trunk"
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update
@@ -72,7 +51,7 @@ jobs:
       # (see https://jwakely.github.io/pkg-gcc-latest/). Not an official GCC
       # release, so this leg is allowed to fail (see continue-on-error above).
       - name: Install GCC trunk snapshot
-        if: matrix.family == 'gcc' && matrix.trunk
+        if: matrix.trunk
         run: |
           wget -q http://kayari.org/gcc-latest/gcc-latest.deb
           sudo dpkg -i gcc-latest.deb || sudo apt-get install -f -y
@@ -82,13 +61,6 @@ jobs:
           echo "LD_LIBRARY_PATH=/opt/gcc-latest/lib64:${LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
           ${{ matrix.cc }} --version
           ${{ matrix.cxx }} --version
-
-      - name: Install Clang ${{ matrix.version }}
-        if: matrix.family == 'clang'
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh ${{ matrix.version }}
 
       - name: Install Boost.Test
         run: sudo apt-get install -y libboost-test-dev

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -3,7 +3,7 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
-name: Windows
+name: MSVC
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
   build:
     name: MSVC ${{ matrix.vs }} (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.preview_channel }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +27,6 @@ jobs:
             toolset: "host=x64"
             arch: x64
             triplet: x64-windows
-            experimental: false
             preview_channel: false
           - vs: 2022
             os: windows-2022
@@ -35,7 +34,6 @@ jobs:
             toolset: "host=x64"
             arch: Win32
             triplet: x86-windows
-            experimental: false
             preview_channel: false
           - vs: 2026
             os: windows-2025
@@ -43,7 +41,6 @@ jobs:
             toolset: "host=x64"
             arch: x64
             triplet: x64-windows
-            experimental: false
             preview_channel: false
           - vs: 2026
             os: windows-2025
@@ -51,7 +48,6 @@ jobs:
             toolset: "host=x64"
             arch: Win32
             triplet: x86-windows
-            experimental: false
             preview_channel: false
           - vs: 2026-Preview
             os: windows-2025
@@ -59,21 +55,7 @@ jobs:
             toolset: "version=Preview,host=x64"
             arch: x64
             triplet: x64-windows
-            experimental: true
             preview_channel: true
-          # clang-cl: Clang's MSVC-compatible driver, using the MSVC STL and
-          # linker rather than libc++. Exercises Clang's diagnostics (this
-          # repo builds with -Weverything -Werror under Clang) against the
-          # same code MSVC builds, using whichever LLVM the runner image
-          # bundles. Best-effort: see continue-on-error above.
-          - vs: 2022-ClangCL
-            os: windows-2022
-            generator: "Visual Studio 17 2022"
-            toolset: "ClangCL,host=x64"
-            arch: x64
-            triplet: x64-windows
-            experimental: true
-            preview_channel: false
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 [![Standard](https://img.shields.io/badge/c%2B%2B-23-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)
 [![License](https://img.shields.io/badge/license-Boost-blue.svg)](https://opensource.org/licenses/BSL-1.0)
 [![Lines of Code](https://tokei.rs/b1/github/rhalbersma/xstd?category=code)](https://github.com/rhalbersma/xstd)
-[![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml)
-[![Windows](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml)
+[![GCC](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml)
+[![Clang](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml)
+[![clang-cl](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml)
+[![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml)
 
 | Header                   | Additions          | Description | Reference |
 | :-----                   | :--------          | :---------- | :-------- |
@@ -20,10 +22,10 @@ These header-only libraries are continuously being tested with the following con
 
 | Platform | Compiler | Older stable | Latest stable | Trunk / Preview | Build |
 | :------- | :------- | :------------ | :------------- | :---------------- | :---- |
-| Linux    | GCC      | 15             | 16              | 17-SVN             | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
-| Linux    | Clang    | 21             | 22              | 23-SVN             | [![Linux](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/linux.yml) |
-| Windows  | Clang (`clang-cl`) | —    | 20.1.8 (bundled) | —               | [![Windows](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml) |
-| Windows  | MSVC     | 2022           | 2026            | 2026-Preview       | [![Windows](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/windows.yml) |
+| Linux    | GCC      | 15             | 16              | 17-SVN             | [![GCC](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml) |
+| Linux    | Clang    | 21             | 22              | 23-SVN             | [![Clang](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml) |
+| Windows  | Clang (`clang-cl`) | —    | 20.1.8 (bundled) | —               | [![clang-cl](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml) |
+| Windows  | MSVC     | 2022           | 2026            | 2026-Preview       | [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml) |
 
 The `Trunk / Preview` column is allowed to fail independently and does not affect the badges above. The `clang-cl` leg tests Clang's diagnostics against the MSVC STL, using whichever LLVM version the Windows runner image bundles. MSVC has no stable `/std:c++23` switch yet, so both MSVC rows build with `/std:c++latest`.
 


### PR DESCRIPTION
## Summary
- Replace `linux.yml`/`windows.yml` with `gcc.yml`, `clang.yml`, `msvc.yml`, and `clang-cl.yml` — one workflow (and one badge) per compiler.
- Behavior is unchanged: same version matrices, same install/configure/build/test steps, same `continue-on-error` semantics for the trunk (`17-SVN`/`23-SVN`), preview (`2026-Preview`), and `clang-cl` legs.
- README badges and the compiler table's `Build` column now point at the matching per-compiler workflow instead of a shared platform one — a regression in one compiler no longer turns another compiler's badge red.

## Why
Makes it easier to add or drop a compiler later (e.g. dropping GCC trunk support, or adding a new one) without touching an unrelated compiler's workflow.

## Test plan
- [ ] Confirm all four workflows trigger and their badges reflect the correct per-compiler status


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_