### PR TITLE
Bump copyright to 2026; fix Clang trunk lifetime-safety warning

### DIFF
--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -1,4 +1,4 @@
-#          Copyright Rein Halbersma 2014-2025.
+#          Copyright Rein Halbersma 2014-2026.
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,4 +1,4 @@
-#          Copyright Rein Halbersma 2014-2025.
+#          Copyright Rein Halbersma 2014-2026.
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -1,4 +1,4 @@
-#          Copyright Rein Halbersma 2014-2025.
+#          Copyright Rein Halbersma 2014-2026.
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,4 +1,4 @@
-#          Copyright Rein Halbersma 2014-2025.
+#          Copyright Rein Halbersma 2014-2026.
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-#          Copyright Rein Halbersma 2014-2025.
+#          Copyright Rein Halbersma 2014-2026.
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ The `Trunk / Preview` column is allowed to fail independently and does not affec
 
 ## License
 
-Copyright Rein Halbersma 2014-2025.
+Copyright Rein Halbersma 2014-2026.
 Distributed under the [Boost Software License, Version 1.0](http://www.boost.org/users/license.html).
 (See accompanying file LICENSE_1_0.txt or copy at [http://www.boost.org/LICENSE_1_0.txt](http://www.boost.org/LICENSE_1_0.txt))

--- a/include/xstd/array.hpp
+++ b/include/xstd/array.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -11,6 +11,12 @@
 #include <tuple>        // tie
 #include <type_traits>  // is_arithmetic_v
 
+#if defined(__clang__)
+#define XSTD_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define XSTD_LIFETIMEBOUND
+#endif
+
 namespace xstd {
 
 template<class T>
@@ -34,13 +40,13 @@ struct div_t
 };
 
 template<class CharT, class Traits>
-auto& operator<<(std::basic_ostream<CharT, Traits>& ostr, div_t const& d)
+auto& operator<<(std::basic_ostream<CharT, Traits>& ostr XSTD_LIFETIMEBOUND, div_t const& d)
 {
         return ostr << ostr.widen('[') << d.quot << ostr.widen(',') << d.rem << ostr.widen(']');
 }
 
 template<class CharT, class Traits>
-auto& operator>>(std::basic_istream<CharT, Traits>& istr, div_t& d)
+auto& operator>>(std::basic_istream<CharT, Traits>& istr XSTD_LIFETIMEBOUND, div_t& d)
 {
         CharT c;
         istr >> c; assert(c == istr.widen('['));
@@ -108,3 +114,5 @@ auto& operator>>(std::basic_istream<CharT, Traits>& istr, div_t& d)
 }
 
 }       // namespace xstd
+
+#undef XSTD_LIFETIMEBOUND

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)

--- a/include/xstd/type_traits.hpp
+++ b/include/xstd/type_traits.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)

--- a/include/xstd/utility.hpp
+++ b/include/xstd/utility.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-#          Copyright Rein Halbersma 2014-2025.
+#          Copyright Rein Halbersma 2014-2026.
 # Distributed under the Boost Software License, Version 1.0.
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -1,4 +1,4 @@
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -1,4 +1,4 @@
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)

--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -1,4 +1,4 @@
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
## Summary
- Bump the `Copyright Rein Halbersma 2014-2025` notice to `2014-2026` across every source file, `CMakeLists.txt`, all four workflow files, and the README's License section.
- Fix the `clang-cl`/Clang trunk (`23-SVN`) build: Clang's new lifetime-safety analysis (`-Wlifetime-safety-intra-tu-suggestions`) flags `xstd::operator<<`/`operator>>` for `div_t`, since they return the same stream reference they're passed — exactly what `[[clang::lifetimebound]]` exists to annotate. Gated to Clang only via an `XSTD_LIFETIMEBOUND` macro, since GCC errors on unrecognized scoped attributes under `-Werror=attributes`.

## Investigation notes (from inspecting the failing SVN builds on the latest commit)
- **Clang 23-SVN**: fixed by the above (verified locally against Clang 18.1, and confirmed GCC 13.3 is unaffected since the macro expands to nothing there).
- **GCC 17-SVN**: the `LD_LIBRARY_PATH` fix from an earlier PR resolved the previous `GLIBCXX_3.4.32` runtime error, but a new failure appeared — `type_traits` fails with `Test setup error: Parameter catch_system_errors`, which looks like an ABI mismatch between the apt-prebuilt Boost.Test library and the from-scratch GCC trunk snapshot compiler. Not addressed here; rebuilding Boost.Test from source with the exact trunk compiler would be the real fix, which is heavy for a best-effort/allow-failure leg.

## Test plan
- [ ] Confirm the Clang 23-SVN leg's build step now passes (or fails for an unrelated reason)
- [ ] Confirm GCC 15/16, Clang 21/22, MSVC, and clang-cl are unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_