### PR TITLE
Fix lifetimebound verification failure on operator&lt;&lt;

### DIFF
--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -42,7 +42,8 @@ struct div_t
 template<class CharT, class Traits>
 auto& operator<<(std::basic_ostream<CharT, Traits>& ostr XSTD_LIFETIMEBOUND, div_t const& d)
 {
-        return ostr << ostr.widen('[') << d.quot << ostr.widen(',') << d.rem << ostr.widen(']');
+        ostr << ostr.widen('[') << d.quot << ostr.widen(',') << d.rem << ostr.widen(']');
+        return ostr;
 }
 
 template<class CharT, class Traits>


### PR DESCRIPTION
## Root cause
Adding `[[clang::lifetimebound]]` in #33 fixed the original `-Wlifetime-safety-intra-tu-suggestions` warning, but exposed a stricter follow-on check:

```
error: could not verify that the return value can be lifetime bound to 'ostr' [-Werror,-Wlifetime-safety-lifetimebound-violation]
auto& operator<<(std::basic_ostream<CharT, Traits>& ostr XSTD_LIFETIMEBOUND, div_t const& d)
```

`operator<<` returned the result of a chained `ostr << ... << ...` expression rather than `ostr` itself. Clang's lifetime analysis can't trace that chain of built-in stream `operator<<` calls back to the annotated parameter, even though the returned reference is in fact always `ostr`.

## Fix
Split the chained insertion from the return, so the function explicitly `return ostr;` — mirroring `operator>>`, which already does this and never triggered the diagnostic.

Verified locally against GCC 13.3 and Clang 18.1 (the specific trunk-only diagnostic isn't reproducible with these older compilers, but the change is a pure refactor with identical behavior).

## Test plan
- [ ] Confirm the Clang 23-SVN leg's build step passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_