### PR TITLE
Enhance GCC trunk install in CI: use HTTPS, export PATH, add symlinks, and configure lib paths

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -53,11 +53,19 @@ jobs:
       - name: Install GCC trunk snapshot
         if: matrix.trunk
         run: |
-          wget -q http://kayari.org/gcc-latest/gcc-latest.deb
+          wget -q https://kayari.org/gcc-latest/gcc-latest.deb
           sudo dpkg -i gcc-latest.deb || sudo apt-get install -f -y
+          echo "/opt/gcc-latest/bin" >> "$GITHUB_PATH"
+          for tool in gcc g++ cc c++ cpp gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool; do
+            if [ -x "/opt/gcc-latest/bin/${tool}" ]; then
+              sudo ln -sf "/opt/gcc-latest/bin/${tool}" "/usr/bin/${tool}-${{ matrix.version }}"
+            fi
+          done
           sudo ln -sf /opt/gcc-latest/bin/gcc /usr/bin/${{ matrix.cc }}
           sudo ln -sf /opt/gcc-latest/bin/g++ /usr/bin/${{ matrix.cxx }}
-          sudo ldconfig /opt/gcc-latest/lib64
+          echo /opt/gcc-latest/lib64 | sudo tee /etc/ld.so.conf.d/gcc-latest.conf
+          sudo ldconfig
+          echo "LD_RUN_PATH=/opt/gcc-latest/lib64" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=/opt/gcc-latest/lib64:${LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
           ${{ matrix.cc }} --version
           ${{ matrix.cxx }} --version


### PR DESCRIPTION
### Motivation
- Use a secure `https` download for the GCC trunk package instead of `http` to avoid mixed-content and network issues.
- Ensure the unpacked trunk snapshot's binaries are available to the Actions runner `PATH` and that commonly used GCC tools are accessible under versioned names.
- Properly configure dynamic linker paths so runtime linking of trunk libraries succeeds in the CI environment.

### Description
- Replaced `wget -q http://kayari.org/gcc-latest/gcc-latest.deb` with `wget -q https://kayari.org/gcc-latest/gcc-latest.deb` to use HTTPS.
- Appended `/opt/gcc-latest/bin` to `GITHUB_PATH` via `echo "/opt/gcc-latest/bin" >> "$GITHUB_PATH"` so the trunk binaries are on the runner `PATH`.
- Added a loop to create versioned symlinks for a set of GCC tools (e.g. `gcc`, `g++`, `gcc-ar`, `gcov`, etc.) into `/usr/bin/${{ matrix.version }}` when present.
- Replaced the direct `ldconfig /opt/gcc-latest/lib64` call with writing `/opt/gcc-latest/lib64` into `/etc/ld.so.conf.d/gcc-latest.conf` and running `sudo ldconfig`, and exported `LD_RUN_PATH` and `LD_LIBRARY_PATH` into `GITHUB_ENV` for runtime linking.
- Kept existing symlinks for `matrix.cc` and `matrix.cxx` and still print compiler versions with `${{ matrix.cc }} --version` and `${{ matrix.cxx }} --version`.

### Testing
- No automated CI runs were executed as part of this change; the workflow update itself will be exercised when GitHub Actions runs the matrix jobs.
- The workflow still runs the existing `Build` step (`cmake --build build -v`) and `Test` step (`ctest --test-dir build --output-on-failure`) when CI is triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57edbfff748332bf92913fedd2657a)