### PR TITLE
Revert two-step operator&lt;&lt; split; suppress the warning instead

### DIFF
--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -42,8 +42,7 @@ struct div_t
 template<class CharT, class Traits>
 auto& operator<<(std::basic_ostream<CharT, Traits>& ostr XSTD_LIFETIMEBOUND, div_t const& d)
 {
-        ostr << ostr.widen('[') << d.quot << ostr.widen(',') << d.rem << ostr.widen(']');
-        return ostr;
+        return ostr << ostr.widen('[') << d.quot << ostr.widen(',') << d.rem << ostr.widen(']');
 }
 
 template<class CharT, class Traits>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set(cxx_compile_options_warnings
         -Wno-global-constructors            # triggered by Boost.Test
         -Wno-used-but-marked-unused         # triggered by Boost.Test
         -Wno-c2y-extensions                 # triggered by Boost.Test's use of __COUNTER__
+        -Wno-lifetime-safety-lifetimebound-violation  # can't verify chained operator<< returns ostr
     >
     $<$<CXX_COMPILER_ID:GNU>:
         -Wall


### PR DESCRIPTION
## Summary
- Revert `operator<<`'s two-step insert-then-return (from #34) back to the single-line chained return.
- Suppress `-Wlifetime-safety-lifetimebound-violation` in `test/CMakeLists.txt`'s Clang warnings block instead, following the same pattern already used for other Boost.Test/Clang-trunk-only diagnostics (`-Wno-c2y-extensions`, etc.).

Verified locally against GCC 13.3 and Clang 18.1 — full build and `ctest` pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_