### PR TITLE
Modernize CMake: require 3.28, add install/export, and refactor tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,20 +3,25 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.28)
 project(
     xstd
-    HOMEPAGE_URL https://github.com/rhalbersma/${PROJECT_NAME}
+    VERSION 0.1.0
+    DESCRIPTION "Extensions to the C++ Standard Library"
+    HOMEPAGE_URL "https://github.com/rhalbersma/xstd"
     LANGUAGES CXX
 )
+
+include(GNUInstallDirs)
 
 add_library(
     ${PROJECT_NAME} INTERFACE
 )
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 set(project_include_dir
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_include_directories(
     ${PROJECT_NAME} INTERFACE
@@ -36,5 +41,23 @@ target_compile_options(
     $<$<CXX_COMPILER_ID:MSVC>:/std:c++latest>
 )
 
-include(CTest)
-add_subdirectory(test)
+option(XSTD_BUILD_TESTING "Build xstd tests" ${PROJECT_IS_TOP_LEVEL})
+
+if(XSTD_BUILD_TESTING)
+    include(CTest)
+    add_subdirectory(test)
+endif()
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}Targets
+)
+install(
+    DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+    EXPORT ${PROJECT_NAME}Targets
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,9 @@ find_package(
     unit_test_framework
 )
 
+add_library(xstd_test_options INTERFACE)
+option(XSTD_WARNINGS_AS_ERRORS "Treat warnings as errors in xstd tests" ${PROJECT_IS_TOP_LEVEL})
+
 set(cxx_compile_definitions
     BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE  # https://github.com/boostorg/config/issues/207
     BOOST_ALL_NO_LIB
@@ -23,7 +26,6 @@ set(cxx_compile_options_warnings
     $<$<CXX_COMPILER_ID:MSVC>:
         /W4
         /permissive-
-        /WX
     >
     $<$<CXX_COMPILER_ID:Clang>:
         -Weverything
@@ -46,7 +48,6 @@ set(cxx_compile_options_warnings
         -Wsign-promo
     >
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
-        -Werror
         -pedantic-errors
     >
 )
@@ -57,8 +58,25 @@ set(cxx_compile_options_mbig_obj
     >
 )
 
+target_compile_definitions(
+    xstd_test_options INTERFACE
+    ${cxx_compile_definitions}
+)
+target_compile_options(
+    xstd_test_options INTERFACE
+    ${cxx_compile_options_warnings}
+    ${cxx_compile_options_mbig_obj}
+    $<$<AND:$<BOOL:${XSTD_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
+    $<$<AND:$<BOOL:${XSTD_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>
+)
+
 set(current_source_dir ${CMAKE_CURRENT_SOURCE_DIR}/src)
-file(GLOB_RECURSE targets RELATIVE ${current_source_dir} *.cpp)
+file(
+    GLOB_RECURSE targets
+    CONFIGURE_DEPENDS
+    RELATIVE ${current_source_dir}
+    ${current_source_dir}/*.cpp
+)
 
 foreach(t ${targets})
     get_filename_component(target_path ${t} PATH)
@@ -70,20 +88,10 @@ foreach(t ${targets})
 
     target_link_libraries(
         ${target_id} PRIVATE
-        ${CMAKE_PROJECT_NAME}
+        ${PROJECT_NAME}::${PROJECT_NAME}
         Boost::unit_test_framework
+        xstd_test_options
     )
 
-    target_compile_definitions(
-        ${target_id} PRIVATE
-        ${cxx_compile_definitions}
-    )
-
-    target_compile_options(
-        ${target_id} PRIVATE
-        ${cxx_compile_options_warnings}
-        ${cxx_compile_options_mbig_obj}
-    )
-
-    add_test(${target_id} ${target_id})
+    add_test(NAME ${target_id} COMMAND ${target_id})
 endforeach()


### PR DESCRIPTION
### Motivation
- Modernize the project's CMake configuration to use newer CMake features and provide proper install/export targets.
- Make test building optional and centralize test compile/link options to simplify and harden test configuration.
- Improve portability by using `GNUInstallDirs` and avoid hardcoded install/include paths.

### Description
- Bump `cmake_minimum_required` to `3.28`, add `VERSION` and `DESCRIPTION` to `project()` and include `GNUInstallDirs` for standard install variables.
- Create an alias target `xstd::xstd`, switch test targets to link against `xstd::xstd`, and add installs for the interface target, headers, and exported CMake targets via `install()` and `EXPORT`.
- Make tests optional with `option(XSTD_BUILD_TESTING ...)` and only include the `test` subdirectory when enabled.
- Refactor `test/CMakeLists.txt` to provide a single interface `xstd_test_options` for compile definitions/options, add `option(XSTD_WARNINGS_AS_ERRORS ...)` to control treating warnings as errors, use `file(... CONFIGURE_DEPENDS ...)` for globs, and use `add_test(NAME ...)` for tests.

### Testing
- Configured and built the project using `cmake` and `cmake --build .` with `XSTD_BUILD_TESTING=ON` to exercise the test tree and installation generation, which completed successfully.
- Ran unit tests with `ctest` from the build directory and all tests passed.
- Verified `cmake --install` generates the `cmake/<project>` export and installs headers to `${CMAKE_INSTALL_INCLUDEDIR}` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57d6b572048332a53abddb3a1ae534)