### PR TITLE
Fix MSVC preview leg: discover VS Insiders instance via vswhere

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -76,6 +76,18 @@ jobs:
             --add Microsoft.VisualStudio.Workload.VCTools `
             --includeRecommended
 
+          # Don't assume where the Insiders instance landed: ask vswhere,
+          # which Microsoft ships specifically for this.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $instance = & $vswhere -prerelease -products * -format json | ConvertFrom-Json |
+            Where-Object { $_.channelId -like "*Insiders*" } |
+            Select-Object -First 1
+          if (-not $instance) {
+            Write-Error "No VS Insiders instance found by vswhere"
+            exit 1
+          }
+          echo "VS_PREVIEW_INSTANCE=$($instance.installationPath)" >> $env:GITHUB_ENV
+
       - name: Install Boost.Test
         shell: pwsh
         run: vcpkg install boost-test:${{ matrix.triplet }}
@@ -96,7 +108,7 @@ jobs:
           cmake -S . -B build
           -G "${{ matrix.generator }}" -A ${{ matrix.arch }}
           -T ${{ matrix.toolset }}
-          -DCMAKE_GENERATOR_INSTANCE="C:/Program Files/Microsoft Visual Studio/18/Insiders"
+          "-DCMAKE_GENERATOR_INSTANCE=$env:VS_PREVIEW_INSTANCE"
           "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build


### PR DESCRIPTION
## Root cause
```
CMake Error at CMakeLists.txt:7 (project):
  Generator
    Visual Studio 18 2026
  could not find specified instance of Visual Studio:
    C:/Program Files/Microsoft Visual Studio/18/Insiders
```

The `CMAKE_GENERATOR_INSTANCE` path was a guess made when this leg was first added, and it doesn't match where `vs_buildtools.exe` actually installs the Insiders channel on the `windows-2025` runner. The install step itself succeeds — we just never verified where it landed.

## Fix
Right after installing, query `vswhere.exe` (which Microsoft ships specifically for discovering installed VS instances, including prerelease/Insiders channels) for the instance whose `channelId` contains `Insiders`, and pass its actual `installationPath` via a `VS_PREVIEW_INSTANCE` env var instead of a hardcoded guess.

I can't fully exercise this against a real Windows runner from here, so treat this as a best-effort fix for a leg that's already `continue-on-error` — if `vswhere` reports something unexpected, we'll see a clearer error in the logs to iterate on next.

## Test plan
- [ ] Confirm the `MSVC 2026-Preview (x64)` leg's Configure step passes, or at least fails with more actionable output
- [ ] Confirm the four stable MSVC legs are unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_