### PR TITLE
CI: improve GCC trunk install - use https, add tool symlinks, and configure libs

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -53,12 +53,21 @@ jobs:
       - name: Install GCC trunk snapshot
         if: matrix.trunk
         run: |
-          wget -q http://kayari.org/gcc-latest/gcc-latest.deb
+          wget -q https://kayari.org/gcc-latest/gcc-latest.deb -O gcc-latest.deb
           sudo dpkg -i gcc-latest.deb || sudo apt-get install -f -y
-          sudo ln -sf /opt/gcc-latest/bin/gcc /usr/bin/${{ matrix.cc }}
-          sudo ln -sf /opt/gcc-latest/bin/g++ /usr/bin/${{ matrix.cxx }}
-          sudo ldconfig /opt/gcc-latest/lib64
-          echo "LD_LIBRARY_PATH=/opt/gcc-latest/lib64:${LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+          sudo ln -sf /opt/gcc-latest/bin/gcc        /usr/bin/${{ matrix.cc }}
+          sudo ln -sf /opt/gcc-latest/bin/g++        /usr/bin/${{ matrix.cxx }}
+          sudo ln -sf /opt/gcc-latest/bin/gcov       /usr/bin/gcov-${{ matrix.version }}
+          sudo ln -sf /opt/gcc-latest/bin/gcov-dump  /usr/bin/gcov-dump-${{ matrix.version }}
+          sudo ln -sf /opt/gcc-latest/bin/gcov-tool  /usr/bin/gcov-tool-${{ matrix.version }}
+          sudo ln -sf /opt/gcc-latest/bin/gcc-ar     /usr/bin/gcc-ar-${{ matrix.version }}
+          sudo ln -sf /opt/gcc-latest/bin/gcc-nm     /usr/bin/gcc-nm-${{ matrix.version }}
+          sudo ln -sf /opt/gcc-latest/bin/gcc-ranlib /usr/bin/gcc-ranlib-${{ matrix.version }}
+          printf '%s\n' \
+            '# Multiarch support' \
+            /opt/gcc-latest/lib \
+            /opt/gcc-latest/lib64 | sudo tee /etc/ld.so.conf.d/gcc-latest.conf > /dev/null
+          sudo ldconfig
           ${{ matrix.cc }} --version
           ${{ matrix.cxx }} --version
 


### PR DESCRIPTION
### Motivation

- Make the GCC trunk installation in CI more reliable by explicitly writing the downloaded file and using HTTPS for the snapshot URL.  
- Expose additional GCC tooling (gcov, gcov-dump, gcov-tool, gcc-ar, gcc-nm, gcc-ranlib) under versioned names so downstream steps can find them.  
- Ensure runtime linker finds GCC libraries by registering `/opt/gcc-latest/lib` and `/opt/gcc-latest/lib64` with `ldconfig` instead of relying on `LD_LIBRARY_PATH`.

### Description

- Use `wget -q https://kayari.org/gcc-latest/gcc-latest.deb -O gcc-latest.deb` to download the trunk snapshot into a known filename.  
- Create versioned symlinks for `gcov`, `gcov-dump`, `gcov-tool`, `gcc-ar`, `gcc-nm`, and `gcc-ranlib` into `/usr/bin` named with the matrix `version`.  
- Add an `/etc/ld.so.conf.d/gcc-latest.conf` containing the new GCC library paths and run `ldconfig` to register them.  
- Remove the `LD_LIBRARY_PATH` environment modification and keep printing the installed compiler versions with `${{ matrix.cc }} --version` and `${{ matrix.cxx }} --version`.

### Testing

- Ran the CI workflow steps for the GCC matrix including trunk which performed install, configure, build, and test.  
- The `cmake` configure and `cmake --build build -v` build steps completed successfully.  
- The test step `ctest --test-dir build --output-on-failure` executed and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57d65e74c88332b823f5d4a693ad31)