### PR TITLE
Increase Boost.Test verbosity under CTest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,5 +94,5 @@ foreach(t ${targets})
         xstd_test_options
     )
 
-    add_test(NAME ${target_id} COMMAND ${target_id})
+    add_test(NAME ${target_id} COMMAND ${target_id} --log_level=all)
 endforeach()


### PR DESCRIPTION
### Motivation
- Ensure Boost.Test executables run with maximum verbosity under CTest so failures (e.g. the GCC-17 `system_error` catch) emit full Boost.Test diagnostics.

### Description
- Pass `--log_level=all` to each test by changing the `add_test` invocation in `test/CMakeLists.txt` to `add_test(NAME ${target_id} COMMAND ${target_id} --log_level=all)`.

### Testing
- Ran `git diff --check` (ok) and attempted `cmake -S . -B build -DXSTD_BUILD_TESTING=ON && cmake --build build && ctest --test-dir build --output-on-failure`, but configuration was blocked because the Boost CMake package is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a580b2bbb1c8332a43f0089d495b466)