### PR TITLE
Build Boost.Test from source for the GCC trunk leg

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -71,14 +71,35 @@ jobs:
           ${{ matrix.cc }} --version
           ${{ matrix.cxx }} --version
 
-      - name: Install Boost.Test
+      - name: Install Boost.Test (stable)
+        if: "!matrix.trunk"
         run: sudo apt-get install -y libboost-test-dev
+
+      # The distro's libboost-test is a prebuilt static archive compiled by an
+      # older, ABI-stable GCC. Linking it against the trunk snapshot has been
+      # observed to break Boost.Test's runtime parameter registration
+      # ("Test setup error: Parameter catch_system_errors"). Building
+      # Boost.Test from source with the same trunk compiler avoids the
+      # mismatch. Version is resolved at runtime so this doesn't go stale.
+      - name: Install Boost.Test (from source, trunk)
+        if: matrix.trunk
+        run: |
+          boost_tag=$(curl -fsSL https://api.github.com/repos/boostorg/boost/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
+          boost_ver=${boost_tag#boost-}
+          wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
+          tar xzf boost.tar.gz
+          cd "boost-${boost_ver}"
+          echo "using gcc : trunk : ${{ matrix.cxx }} ;" > user-config.jam
+          ./bootstrap.sh --prefix=/opt/boost-latest --with-libraries=test
+          ./b2 install -j"$(nproc)" --prefix=/opt/boost-latest --user-config=user-config.jam toolset=gcc-trunk variant=release link=static threading=multi
+          echo "BOOST_ROOT=/opt/boost-latest" >> "$GITHUB_ENV"
 
       - name: Configure
         run: >
           cmake -S . -B build
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+          ${{ matrix.trunk && '-DCMAKE_PREFIX_PATH=/opt/boost-latest -DBoost_NO_SYSTEM_PATHS=ON' || '' }}
 
       - name: Build
         run: cmake --build build -v


### PR DESCRIPTION
## Summary

- The GCC 17-SVN (trunk) leg has been consistently failing at the `Test` step with `Test setup error: Parameter catch_system_errors` from Boost.Test, specifically on the `type_traits` test binary — confirmed reproducible across multiple recent CI runs on `master`.
- Root cause: the distro's `libboost-test-dev` is a prebuilt static archive compiled by an older, ABI-stable GCC. Linking it against the bleeding-edge, unofficial GCC trunk snapshot appears to break Boost.Test's internal runtime-parameter registration.
- Fix: for the trunk leg only, build Boost.Test from source using the same trunk compiler (`g++-17`), so the whole binary is compiled by one consistent toolchain. The Boost version is resolved dynamically via the GitHub releases API (`boostorg/boost`) rather than hardcoded, so this doesn't go stale.
- The stable legs (GCC 15, 16) keep installing `libboost-test-dev` via apt, unchanged.

## Test plan

- [ ] CI: GCC 15/16 legs still build and pass using the apt-installed Boost.Test (unchanged behavior).
- [ ] CI: GCC 17-SVN leg installs Boost.Test from source with the trunk compiler, and the `type_traits` test no longer fails with the `catch_system_errors` setup error.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_