### PR TITLE
Don't pass -pedantic-errors to clang-cl

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,14 @@ find_package(
 add_library(xstd_test_options INTERFACE)
 option(XSTD_WARNINGS_AS_ERRORS "Treat warnings as errors in xstd tests" ${PROJECT_IS_TOP_LEVEL})
 
+# clang-cl reports CXX_COMPILER_ID Clang but only understands its MSVC-style
+# driver flags, not GNU-style ones like -pedantic-errors.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+    set(xstd_is_clang_cl ON)
+else()
+    set(xstd_is_clang_cl OFF)
+endif()
+
 set(cxx_compile_definitions
     BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE  # https://github.com/boostorg/config/issues/207
     BOOST_ALL_NO_LIB
@@ -48,7 +56,7 @@ set(cxx_compile_options_warnings
         -Wsign-conversion
         -Wsign-promo
     >
-    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
+    $<$<AND:$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<BOOL:${xstd_is_clang_cl}>>>:
         -pedantic-errors
     >
 )


### PR DESCRIPTION
## Summary

- clang-cl was failing with `clang-cl: -pedantic-errors [-Werror,-Wunknown-argument]`.
- clang-cl reports `CMAKE_CXX_COMPILER_ID` as `Clang`, so the existing `$<CXX_COMPILER_ID:Clang>` condition on `-pedantic-errors` applied to it too. But clang-cl's driver only understands MSVC-style flags plus a whitelisted set of Clang `-W` flags — GNU-style `-pedantic-errors` isn't among them, so it's rejected as an unknown argument, which `-Werror` then escalates to a hard failure.
- Fix: detect clang-cl via `CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"` (there's no generator-expression equivalent, so this is resolved as a plain CMake variable at configure time) and exclude it from `-pedantic-errors`. Plain Clang and GCC are unaffected.

## Test plan

- [x] Verified locally with GCC 13 and Clang 18 (both frontend variant GNU): `-pedantic-errors` still applied, all 3 tests pass.
- [ ] CI: clang-cl leg no longer fails on `-pedantic-errors`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_