### PR TITLE
Drop Win32 MSVC legs, fix the MSVC 2026-Preview toolset install

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -52,10 +52,15 @@ jobs:
         if: matrix.preview_channel
         shell: pwsh
         run: |
+          # Write-Error is a terminating error in GitHub Actions' pwsh steps
+          # (ErrorActionPreference=Stop), which was silently swallowing every
+          # diagnostic line after the first Write-Error call in here. Use
+          # Write-Host for anything meant to actually be seen, and reserve
+          # exit 1 as the real terminator.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $instance = & $vswhere -products * -format json | ConvertFrom-Json | Select-Object -First 1
           if (-not $instance) {
-            Write-Error "No VS instance found by vswhere to add the Preview toolset to"
+            Write-Host "No VS instance found by vswhere to add the Preview toolset to"
             exit 1
           }
 
@@ -73,13 +78,13 @@ jobs:
           # it actually landed before moving on.
           $verify = & $vswhere -requires Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64 -format json | ConvertFrom-Json
           if ($setupExit -ne 0 -or -not $verify) {
-            Write-Error "Preview toolset not present after setup.exe modify (exit code $setupExit). Dumping the newest VS Installer log:"
+            Write-Host "Preview toolset not present after setup.exe modify (exit code $setupExit). Dumping the newest VS Installer log:"
             $log = Get-ChildItem "$env:TEMP\dd_*.log" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1
             if ($log) {
-              Write-Error "--- $($log.FullName) (last 150 lines) ---"
-              Get-Content $log.FullName -Tail 150 | ForEach-Object { Write-Error $_ }
+              Write-Host "--- $($log.FullName) (last 150 lines) ---"
+              Get-Content $log.FullName -Tail 150 | ForEach-Object { Write-Host $_ }
             } else {
-              Write-Error "No dd_*.log found under $env:TEMP"
+              Write-Host "No dd_*.log found under $env:TEMP"
             }
             exit 1
           }

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -59,12 +59,24 @@ jobs:
             exit 1
           }
 
+          # setup.exe (the already-installed VS Installer engine) has a
+          # different CLI surface than the vs_buildtools.exe bootstrapper -
+          # no --wait flag; --quiet already blocks until done.
           $setup = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
-          & $setup modify --quiet --wait --norestart --nocache `
+          & $setup modify --quiet --norestart --nocache `
             --installPath "$($instance.installationPath)" `
             --add Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64
           if ($LASTEXITCODE -ne 0) {
             Write-Error "setup.exe modify failed with exit code $LASTEXITCODE"
+            exit 1
+          }
+
+          # setup.exe has been seen to exit 0 even when it only printed a
+          # usage/argument error, so don't just trust the exit code: confirm
+          # the component actually landed before moving on.
+          $verify = & $vswhere -requires Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64 -format json | ConvertFrom-Json
+          if (-not $verify) {
+            Write-Error "Preview toolset component not found after setup.exe modify"
             exit 1
           }
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -66,11 +66,17 @@ jobs:
 
           # setup.exe (the already-installed VS Installer engine) has a
           # different CLI surface than the vs_buildtools.exe bootstrapper -
-          # no --wait flag; --quiet already blocks until done.
+          # no --wait flag; --quiet already blocks until done. A bare
+          # component --add silently no-op'd (confirmed: no new dd_*.log
+          # appeared at all), so add the whole workload plus recommended
+          # components instead, matching what the original working
+          # side-by-side install always did.
           $setup = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
           & $setup modify --quiet --norestart --nocache `
             --installPath "$($instance.installationPath)" `
-            --add Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64
+            --add Microsoft.VisualStudio.Workload.VCTools `
+            --add Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64 `
+            --includeRecommended --includeOptional
           $setupExit = $LASTEXITCODE
 
           # setup.exe has been seen to exit 0 even when it didn't actually

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -66,17 +66,21 @@ jobs:
           & $setup modify --quiet --norestart --nocache `
             --installPath "$($instance.installationPath)" `
             --add Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "setup.exe modify failed with exit code $LASTEXITCODE"
-            exit 1
-          }
+          $setupExit = $LASTEXITCODE
 
-          # setup.exe has been seen to exit 0 even when it only printed a
-          # usage/argument error, so don't just trust the exit code: confirm
-          # the component actually landed before moving on.
+          # setup.exe has been seen to exit 0 even when it didn't actually
+          # add the component, so don't just trust the exit code: confirm
+          # it actually landed before moving on.
           $verify = & $vswhere -requires Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64 -format json | ConvertFrom-Json
-          if (-not $verify) {
-            Write-Error "Preview toolset component not found after setup.exe modify"
+          if ($setupExit -ne 0 -or -not $verify) {
+            Write-Error "Preview toolset not present after setup.exe modify (exit code $setupExit). Dumping the newest VS Installer log:"
+            $log = Get-ChildItem "$env:TEMP\dd_*.log" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+            if ($log) {
+              Write-Error "--- $($log.FullName) (last 150 lines) ---"
+              Get-Content $log.FullName -Tail 150 | ForEach-Object { Write-Error $_ }
+            } else {
+              Write-Error "No dd_*.log found under $env:TEMP"
+            }
             exit 1
           }
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -34,63 +34,52 @@ jobs:
           - vs: 2026-Preview
             os: windows-2025
             generator: "Visual Studio 18 2026"
-            toolset: "version=Preview,host=x64"
             preview_channel: true
 
     steps:
       - uses: actions/checkout@v4
 
-      # Best-effort, currently broken: the windows-2025 runner image now
-      # ships VS 2026 Stable preinstalled, so the old approach (a separate
-      # Insiders channel installed side-by-side via vs_buildtools.exe)
-      # silently no-ops - the bootstrapper unpacks itself and exits without
-      # installing anything. Adding the Preview toolset to the existing
-      # instance via the VS Installer's own "setup.exe modify" was the next
-      # attempt (first with just the Preview component, then with the full
-      # VCTools workload + --includeRecommended --includeOptional) but that
-      # no-ops too: no new %TEMP%\dd_*.log ever appears, exit code 0, nothing
-      # installed. Root cause not yet identified - possibly setup.exe modify
-      # needs different permissions/flags in this runner environment, or the
-      # Preview toolset simply isn't obtainable this way on this image.
-      # continue-on-error means this doesn't block anything; left failing
-      # with the diagnostics below rather than guessing further.
+      # Best-effort: the windows-2025 runner image ships VS 2026 Stable
+      # preinstalled, and the Preview MSVC toolset is an optional component
+      # on the Stable channel (see the "MSVC Build Tools Preview: How to Opt
+      # In" C++ team blog posts), so it can be added to the existing
+      # instance with the VS Installer's own "modify" command. Two hard-won
+      # gotchas live here:
+      #   1. setup.exe is a GUI-subsystem executable: PowerShell's call
+      #      operator (&) does NOT wait for it, silently leaving a stale
+      #      $LASTEXITCODE and letting the job kill the install as an orphan
+      #      process at teardown. Start-Process -Wait is required (GitHub's
+      #      own runner-images build scripts do the same, treating exit
+      #      codes 0 and 3010 as success).
+      #   2. CMake's "-T version=" only accepts numeric toolset versions,
+      #      not "Preview", so the installed preview version is discovered
+      #      afterwards and passed to Configure via $GITHUB_ENV.
       - name: Install MSVC Preview toolset
         if: matrix.preview_channel
         shell: pwsh
         run: |
-          # Write-Error is a terminating error in GitHub Actions' pwsh steps
-          # (ErrorActionPreference=Stop), which was silently swallowing every
-          # diagnostic line after the first Write-Error call in here. Use
-          # Write-Host for anything meant to actually be seen, and reserve
-          # exit 1 as the real terminator.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $instance = & $vswhere -products * -format json | ConvertFrom-Json | Select-Object -First 1
           if (-not $instance) {
             Write-Host "No VS instance found by vswhere to add the Preview toolset to"
             exit 1
           }
+          $installPath = $instance.installationPath
 
-          # setup.exe (the already-installed VS Installer engine) has a
-          # different CLI surface than the vs_buildtools.exe bootstrapper -
-          # no --wait flag; --quiet already blocks until done. A bare
-          # component --add silently no-op'd (confirmed: no new dd_*.log
-          # appeared at all), so add the whole workload plus recommended
-          # components instead, matching what the original working
-          # side-by-side install always did.
           $setup = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
-          & $setup modify --quiet --norestart --nocache `
-            --installPath "$($instance.installationPath)" `
-            --add Microsoft.VisualStudio.Workload.VCTools `
-            --add Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64 `
-            --includeRecommended --includeOptional
-          $setupExit = $LASTEXITCODE
+          $proc = Start-Process -FilePath $setup -Wait -PassThru -ArgumentList (
+            'modify', '--quiet', '--norestart', '--nocache',
+            '--installPath', "`"$installPath`"",
+            '--add', 'Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64'
+          )
+          # 3010 = success, reboot required
+          $ok = $proc.ExitCode -eq 0 -or $proc.ExitCode -eq 3010
 
-          # setup.exe has been seen to exit 0 even when it didn't actually
-          # add the component, so don't just trust the exit code: confirm
-          # it actually landed before moving on.
-          $verify = & $vswhere -requires Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64 -format json | ConvertFrom-Json
-          if ($setupExit -ne 0 -or -not $verify) {
-            Write-Host "Preview toolset not present after setup.exe modify (exit code $setupExit). Dumping the newest VS Installer log:"
+          $verify = & $vswhere -products * -requires Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64 -format json | ConvertFrom-Json
+          if (-not $ok -or -not $verify) {
+            Write-Host "Preview toolset not present after setup.exe modify (exit code $($proc.ExitCode))."
+            Write-Host "Toolsets present under VC\Tools\MSVC:"
+            Get-ChildItem "$installPath\VC\Tools\MSVC" -Directory -ErrorAction SilentlyContinue | ForEach-Object { Write-Host "  $($_.Name)" }
             $log = Get-ChildItem "$env:TEMP\dd_*.log" -ErrorAction SilentlyContinue | Sort-Object LastWriteTime -Descending | Select-Object -First 1
             if ($log) {
               Write-Host "--- $($log.FullName) (last 150 lines) ---"
@@ -101,16 +90,35 @@ jobs:
             exit 1
           }
 
+          # CMake can't be told "version=Preview"; find the preview
+          # toolset's actual version number (the highest one installed).
+          $default = (Get-Content "$installPath\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt").Trim()
+          $newest = Get-ChildItem "$installPath\VC\Tools\MSVC" -Directory |
+            Sort-Object { [version]$_.Name } -Descending |
+            Select-Object -First 1 -ExpandProperty Name
+          Write-Host "Default toolset: $default; newest (preview) toolset: $newest"
+          echo "VC_PREVIEW_TOOLSET=$newest" >> $env:GITHUB_ENV
+
       - name: Install Boost.Test
         shell: pwsh
         run: vcpkg install boost-test:x64-windows
 
       - name: Configure
+        if: "!matrix.preview_channel"
         shell: pwsh
         run: >
           cmake -S . -B build
           -G "${{ matrix.generator }}" -A x64
           -T ${{ matrix.toolset }}
+          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Configure (preview toolset)
+        if: matrix.preview_channel
+        shell: pwsh
+        run: >
+          cmake -S . -B build
+          -G "${{ matrix.generator }}" -A x64
+          -T "version=$env:VC_PREVIEW_TOOLSET,host=x64"
           "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -40,59 +40,44 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Best-effort: installs the VS 2026 Insiders channel side-by-side with
-      # the pre-installed Stable channel, to get at the MSVC Preview toolset.
-      # This is not an officially supported CI configuration, so this leg is
-      # allowed to fail (see continue-on-error above).
-      - name: Install MSVC Preview channel
+      # Best-effort: the windows-2025 runner image ships VS 2026 Stable
+      # preinstalled, so there's no separate Insiders channel to install
+      # side-by-side anymore (that used to silently no-op here once the
+      # image started bundling VS 2026). The Preview MSVC toolset is just an
+      # optional component on top of the existing installation, added via
+      # the VS Installer's own "modify" command - no channel manifest, no
+      # extra side-by-side product, and CMake finds the same default
+      # instance it already uses for the stable leg.
+      - name: Install MSVC Preview toolset
         if: matrix.preview_channel
         shell: pwsh
         run: |
-          Invoke-WebRequest -Uri https://aka.ms/vs/18/insiders/channel -OutFile VisualStudio.chman
-          Invoke-WebRequest -Uri https://aka.ms/vs/18/insiders/vs_buildtools.exe -OutFile vs_buildtools.exe
-          ./vs_buildtools.exe --quiet --wait --norestart --nocache `
-            --channelUri VisualStudio.chman `
-            --installChannelUri VisualStudio.chman `
-            --add Microsoft.VisualStudio.Workload.VCTools `
-            --includeRecommended
-
-          # Don't assume where the Insiders instance landed, and don't rely on
-          # channelId string matching (its format has changed on us before):
-          # vswhere's -prerelease flag surfaces a boolean isPrerelease field
-          # per instance, which is the documented, stable way to identify it.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $allInstances = & $vswhere -prerelease -products * -format json | ConvertFrom-Json
-          $instance = $allInstances | Where-Object { $_.isPrerelease } | Select-Object -First 1
+          $instance = & $vswhere -products * -format json | ConvertFrom-Json | Select-Object -First 1
           if (-not $instance) {
-            Write-Error "No prerelease VS instance found by vswhere. All instances seen:"
-            foreach ($i in $allInstances) {
-              Write-Error "  path=$($i.installationPath) channelId=$($i.channelId) isPrerelease=$($i.isPrerelease) installationVersion=$($i.installationVersion)"
-            }
+            Write-Error "No VS instance found by vswhere to add the Preview toolset to"
             exit 1
           }
-          echo "VS_PREVIEW_INSTANCE=$($instance.installationPath)" >> $env:GITHUB_ENV
+
+          $setup = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+          & $setup modify --quiet --wait --norestart --nocache `
+            --installPath "$($instance.installationPath)" `
+            --add Microsoft.VisualStudio.Component.VC.Preview.Tools.x86.x64
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "setup.exe modify failed with exit code $LASTEXITCODE"
+            exit 1
+          }
 
       - name: Install Boost.Test
         shell: pwsh
         run: vcpkg install boost-test:x64-windows
 
       - name: Configure
-        if: "!matrix.preview_channel"
         shell: pwsh
         run: >
           cmake -S . -B build
           -G "${{ matrix.generator }}" -A x64
           -T ${{ matrix.toolset }}
-          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
-
-      - name: Configure (preview toolset)
-        if: matrix.preview_channel
-        shell: pwsh
-        run: >
-          cmake -S . -B build
-          -G "${{ matrix.generator }}" -A x64
-          -T ${{ matrix.toolset }}
-          "-DCMAKE_GENERATOR_INSTANCE=$env:VS_PREVIEW_INSTANCE"
           "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    name: MSVC ${{ matrix.vs }} (${{ matrix.arch }})
+    name: MSVC ${{ matrix.vs }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.preview_channel }}
     strategy:
@@ -25,36 +25,16 @@ jobs:
             os: windows-2022
             generator: "Visual Studio 17 2022"
             toolset: "host=x64"
-            arch: x64
-            triplet: x64-windows
-            preview_channel: false
-          - vs: 2022
-            os: windows-2022
-            generator: "Visual Studio 17 2022"
-            toolset: "host=x64"
-            arch: Win32
-            triplet: x86-windows
             preview_channel: false
           - vs: 2026
             os: windows-2025
             generator: "Visual Studio 18 2026"
             toolset: "host=x64"
-            arch: x64
-            triplet: x64-windows
-            preview_channel: false
-          - vs: 2026
-            os: windows-2025
-            generator: "Visual Studio 18 2026"
-            toolset: "host=x64"
-            arch: Win32
-            triplet: x86-windows
             preview_channel: false
           - vs: 2026-Preview
             os: windows-2025
             generator: "Visual Studio 18 2026"
             toolset: "version=Preview,host=x64"
-            arch: x64
-            triplet: x64-windows
             preview_channel: true
 
     steps:
@@ -76,28 +56,32 @@ jobs:
             --add Microsoft.VisualStudio.Workload.VCTools `
             --includeRecommended
 
-          # Don't assume where the Insiders instance landed: ask vswhere,
-          # which Microsoft ships specifically for this.
+          # Don't assume where the Insiders instance landed, and don't rely on
+          # channelId string matching (its format has changed on us before):
+          # vswhere's -prerelease flag surfaces a boolean isPrerelease field
+          # per instance, which is the documented, stable way to identify it.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $instance = & $vswhere -prerelease -products * -format json | ConvertFrom-Json |
-            Where-Object { $_.channelId -like "*Insiders*" } |
-            Select-Object -First 1
+          $allInstances = & $vswhere -prerelease -products * -format json | ConvertFrom-Json
+          $instance = $allInstances | Where-Object { $_.isPrerelease } | Select-Object -First 1
           if (-not $instance) {
-            Write-Error "No VS Insiders instance found by vswhere"
+            Write-Error "No prerelease VS instance found by vswhere. All instances seen:"
+            foreach ($i in $allInstances) {
+              Write-Error "  path=$($i.installationPath) channelId=$($i.channelId) isPrerelease=$($i.isPrerelease) installationVersion=$($i.installationVersion)"
+            }
             exit 1
           }
           echo "VS_PREVIEW_INSTANCE=$($instance.installationPath)" >> $env:GITHUB_ENV
 
       - name: Install Boost.Test
         shell: pwsh
-        run: vcpkg install boost-test:${{ matrix.triplet }}
+        run: vcpkg install boost-test:x64-windows
 
       - name: Configure
         if: "!matrix.preview_channel"
         shell: pwsh
         run: >
           cmake -S . -B build
-          -G "${{ matrix.generator }}" -A ${{ matrix.arch }}
+          -G "${{ matrix.generator }}" -A x64
           -T ${{ matrix.toolset }}
           "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
@@ -106,7 +90,7 @@ jobs:
         shell: pwsh
         run: >
           cmake -S . -B build
-          -G "${{ matrix.generator }}" -A ${{ matrix.arch }}
+          -G "${{ matrix.generator }}" -A x64
           -T ${{ matrix.toolset }}
           "-DCMAKE_GENERATOR_INSTANCE=$env:VS_PREVIEW_INSTANCE"
           "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -40,14 +40,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Best-effort: the windows-2025 runner image ships VS 2026 Stable
-      # preinstalled, so there's no separate Insiders channel to install
-      # side-by-side anymore (that used to silently no-op here once the
-      # image started bundling VS 2026). The Preview MSVC toolset is just an
-      # optional component on top of the existing installation, added via
-      # the VS Installer's own "modify" command - no channel manifest, no
-      # extra side-by-side product, and CMake finds the same default
-      # instance it already uses for the stable leg.
+      # Best-effort, currently broken: the windows-2025 runner image now
+      # ships VS 2026 Stable preinstalled, so the old approach (a separate
+      # Insiders channel installed side-by-side via vs_buildtools.exe)
+      # silently no-ops - the bootstrapper unpacks itself and exits without
+      # installing anything. Adding the Preview toolset to the existing
+      # instance via the VS Installer's own "setup.exe modify" was the next
+      # attempt (first with just the Preview component, then with the full
+      # VCTools workload + --includeRecommended --includeOptional) but that
+      # no-ops too: no new %TEMP%\dd_*.log ever appears, exit code 0, nothing
+      # installed. Root cause not yet identified - possibly setup.exe modify
+      # needs different permissions/flags in this runner environment, or the
+      # Preview toolset simply isn't obtainable this way on this image.
+      # continue-on-error means this doesn't block anything; left failing
+      # with the diagnostics below rather than guessing further.
       - name: Install MSVC Preview toolset
         if: matrix.preview_channel
         shell: pwsh


### PR DESCRIPTION
## Summary

- Drop the Win32 (`x86-windows`) matrix legs for MSVC 2022 and 2026 — x64 only from now on.
- Fix the MSVC 2026-Preview leg, which had been silently broken for a while. Root cause was twofold:
  1. **The install never ran.** The `windows-2025-vs2026` runner image ships VS 2026 Stable preinstalled, so the Preview MSVC toolset must be added to that instance via `setup.exe modify`. But `setup.exe` is a GUI-subsystem executable: PowerShell's call operator (`&`) doesn't wait for it, `$LASTEXITCODE` was a stale 0 from the preceding `vswhere` call, and the actual install was killed as an orphan process at job teardown — before it could install anything or even write a log. The fix (matching GitHub's own runner-images build scripts) is `Start-Process -Wait -PassThru`, reading `$proc.ExitCode` and accepting 0 and 3010 (reboot required) as success, plus a `vswhere -requires` verification that the component actually landed.
  2. **`-T version=Preview` was never valid CMake.** CMake's `version=` toolset field only accepts numeric versions. The workflow now discovers the preview toolset's real version number (the highest-versioned directory under `VC\Tools\MSVC`) after install and passes that to a dedicated Configure step via `$GITHUB_ENV`.

## Test plan

- [x] CI: MSVC 2022 and 2026 legs build x64 only (no more Win32 jobs) — green.
- [x] CI: MSVC 2026-Preview leg installs the Preview toolset (~10 min, real install), configures with the discovered toolset version, builds, and passes all tests — green.
