### PR TITLE
Update README: add project overview, usage, build & test instructions, and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,42 @@
 [![clang-cl](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml)
 [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml)
 
+xstd is a header-only C++23 library for small standard-library extensions that can be implemented portably with stable compiler technology. It aims to prototype future-stdlib-style facilities without requiring experimental language features.
+
 | Header                   | Additions          | Description | Reference |
 | :-----                   | :--------          | :---------- | :-------- |
 | `<xstd/array.hpp>`       | `array_from_types` | Create an `array` from a type list | none |
 | `<xstd/cstdlib.hpp>`     | `abs` <br> `div` <br> `euclidean_div` <br> `floored_div` <br> `sign` | `constexpr std::abs(int)` <br> `constexpr std::div(int, int)` <br> Euclidean division <br> Floored division <br> `constexpr boost::math::sign` | [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) <br> [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) |
 | `<xstd/type_traits.hpp>` | `is_specialization_of` <br> `is_integral_constant` <br> `tagged_empty` <br> `optional_type` | Is a type a class template specialization? <br> Is a type an `integral_constant`? <br> A tagged empty type <br> An optional type | [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) <br> none <br> none <br> none |
 | `<xstd/utility.hpp>`     | `to_underlying`    | Preserve a compile-time constant through `std::to_underlying` (C++23) | none |
+
+## Using xstd
+
+Link the header-only CMake target from your own target:
+
+```cmake
+target_link_libraries(my_target PRIVATE xstd::xstd)
+```
+
+The target publishes the `include/` directory and requires C++23. You can also include individual headers directly, such as `<xstd/cstdlib.hpp>` or `<xstd/type_traits.hpp>`.
+
+## Building and testing
+
+Configure, build, and run the test suite with CMake and CTest:
+
+```sh
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+Tests require Boost.UnitTest.
+
+## Project layout
+
+- `include/xstd/` contains the public header-only library code.
+- `test/src/` contains Boost.Test unit tests, with one executable generated per `.cpp` file.
+- `doc/` contains historical proposal documents and design notes that provide background but are not the current public API.
 
 ## Requirements
 


### PR DESCRIPTION
### Motivation

- Provide a concise description of the `xstd` library and its goals as a header-only C++23 extension collection.
- Document how to consume the library from CMake and how to include individual headers to lower the barrier to adoption.
- Add build and test instructions and an explicit project layout so contributors can run and extend the test suite consistently.

### Description

- Added an introductory paragraph describing `xstd`, its portability goals, and that it is header-only.
- Added a `Using xstd` section with a `target_link_libraries(my_target PRIVATE xstd::xstd)` example and guidance about including individual headers such as `<xstd/cstdlib.hpp>`.
- Added a `Building and testing` section showing the CMake/CTest workflow with the commands `cmake -S . -B build`, `cmake --build build`, and `ctest --test-dir build --output-on-failure`, and noted that tests require Boost.UnitTest.
- Added a `Project layout` section describing `include/xstd/`, `test/src/`, and `doc/`, and made small formatting and metadata updates in the README.

### Testing

- No automated tests were run because this is a documentation-only change.
- Existing CI workflows remain unchanged and will continue to exercise the test suite on code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5803ededd48332ac253c47012b71be)