### PR TITLE
Build the latest Boost from source on every CI leg

### DIFF
--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -42,15 +42,32 @@ jobs:
         shell: pwsh
         run: |
           $headers = @{ Authorization = "Bearer ${{ github.token }}" }
-          $release = Invoke-RestMethod -Uri https://api.github.com/repos/boostorg/boost/releases/latest -Headers $headers
+          # /releases/latest can return a beta (boostorg doesn't always flag
+          # them as prerelease), so list releases and keep strict boost-X.Y.Z
+          $release = (Invoke-RestMethod -Uri "https://api.github.com/repos/boostorg/boost/releases?per_page=20" -Headers $headers) |
+            Where-Object { $_.tag_name -match '^boost-\d+\.\d+\.\d+$' } | Select-Object -First 1
           $tag = $release.tag_name
           $ver = $tag -replace '^boost-', ''
           Invoke-WebRequest -Uri "https://github.com/boostorg/boost/releases/download/$tag/boost-$ver-b2-nodocs.tar.gz" -OutFile boost.tar.gz
           tar -xzf boost.tar.gz
           cd "boost-$ver"
+
+          # CMake's ClangCL toolset uses the clang-cl bundled with Visual
+          # Studio, but PATH has a newer standalone LLVM; if b2 picks up the
+          # latter, BoostConfig rejects the libs over the compiler-version
+          # tag in their names (clangw20 vs clangw19). Pin b2 to the exact
+          # same clang-cl binary the VS toolset will use.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $clangcl = & $vswhere -latest -products * -find 'VC\Tools\Llvm\x64\bin\clang-cl.exe' | Select-Object -First 1
+          if (-not $clangcl) {
+            Write-Host "clang-cl.exe not found via vswhere"
+            exit 1
+          }
+          "using clang-win : : `"$($clangcl -replace '\\', '/')`" ;" | Set-Content user-config.jam
+
           .\bootstrap.bat
           if ($LASTEXITCODE -ne 0) { exit 1 }
-          .\b2 install --prefix=C:\boost-latest --with-test toolset=clang-win address-model=64 variant=release link=static threading=multi
+          .\b2 install --prefix=C:\boost-latest --user-config=user-config.jam --with-test toolset=clang-win address-model=64 variant=release link=static threading=multi
           if ($LASTEXITCODE -ne 0) { exit 1 }
 
       - name: Configure

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -29,14 +29,29 @@ jobs:
           - generator: "Visual Studio 17 2022"
             toolset: "ClangCL,host=x64"
             arch: x64
-            triplet: x64-windows
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Boost.Test
+      # Build the latest Boost release from source with clang-cl itself
+      # (b2's clang-win toolset), so the whole binary is produced by one
+      # toolchain instead of taking vcpkg's prebuilt/pinned version. The
+      # version is resolved via the GitHub API so this doesn't go stale;
+      # the token avoids anonymous rate limits on shared runner IPs.
+      - name: Install Boost.Test (from source)
         shell: pwsh
-        run: vcpkg install boost-test:${{ matrix.triplet }}
+        run: |
+          $headers = @{ Authorization = "Bearer ${{ github.token }}" }
+          $release = Invoke-RestMethod -Uri https://api.github.com/repos/boostorg/boost/releases/latest -Headers $headers
+          $tag = $release.tag_name
+          $ver = $tag -replace '^boost-', ''
+          Invoke-WebRequest -Uri "https://github.com/boostorg/boost/releases/download/$tag/boost-$ver-b2-nodocs.tar.gz" -OutFile boost.tar.gz
+          tar -xzf boost.tar.gz
+          cd "boost-$ver"
+          .\bootstrap.bat
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+          .\b2 install --prefix=C:\boost-latest --with-test toolset=clang-win address-model=64 variant=release link=static threading=multi
+          if ($LASTEXITCODE -ne 0) { exit 1 }
 
       - name: Configure
         shell: pwsh
@@ -44,7 +59,8 @@ jobs:
           cmake -S . -B build
           -G "${{ matrix.generator }}" -A ${{ matrix.arch }}
           -T ${{ matrix.toolset }}
-          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          -DCMAKE_PREFIX_PATH=C:/boost-latest
+          -DBoost_NO_SYSTEM_PATHS=ON
 
       - name: Build
         shell: pwsh

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -46,14 +46,29 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.version }}
 
-      - name: Install Boost.Test
-        run: sudo apt-get install -y libboost-test-dev
+      # Build the latest Boost release from source with the same compiler as
+      # the tests, so the whole binary is produced by one toolchain (the
+      # distro's libboost-test is both ancient and compiled by an older GCC).
+      # The version is resolved via the GitHub API so this doesn't go stale;
+      # the token avoids anonymous rate limits on shared runner IPs.
+      - name: Install Boost.Test (from source)
+        run: |
+          boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/boostorg/boost/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
+          boost_ver=${boost_tag#boost-}
+          wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
+          tar xzf boost.tar.gz
+          cd "boost-${boost_ver}"
+          echo "using clang : ci : ${{ matrix.cxx }} ;" > user-config.jam
+          ./bootstrap.sh --prefix=/opt/boost-latest --with-libraries=test
+          ./b2 install -j"$(nproc)" --prefix=/opt/boost-latest --user-config=user-config.jam toolset=clang-ci variant=release link=static threading=multi
 
       - name: Configure
         run: >
           cmake -S . -B build
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+          -DCMAKE_PREFIX_PATH=/opt/boost-latest
+          -DBoost_NO_SYSTEM_PATHS=ON
 
       - name: Build
         run: cmake --build build -v

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -53,7 +53,9 @@ jobs:
       # the token avoids anonymous rate limits on shared runner IPs.
       - name: Install Boost.Test (from source)
         run: |
-          boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/boostorg/boost/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
+          # /releases/latest can return a beta (boostorg doesn't always flag
+          # them as prerelease), so list releases and keep strict boost-X.Y.Z
+          boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/boostorg/boost/releases?per_page=20" | grep '"tag_name"' | cut -d'"' -f4 | grep -E -m1 '^boost-[0-9]+\.[0-9]+\.[0-9]+$')
           boost_ver=${boost_tag#boost-}
           wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
           tar xzf boost.tar.gz

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -71,35 +71,30 @@ jobs:
           ${{ matrix.cc }} --version
           ${{ matrix.cxx }} --version
 
-      - name: Install Boost.Test (stable)
-        if: "!matrix.trunk"
-        run: sudo apt-get install -y libboost-test-dev
-
-      # The distro's libboost-test is a prebuilt static archive compiled by an
-      # older, ABI-stable GCC. Linking it against the trunk snapshot has been
-      # observed to break Boost.Test's runtime parameter registration
-      # ("Test setup error: Parameter catch_system_errors"). Building
-      # Boost.Test from source with the same trunk compiler avoids the
-      # mismatch. Version is resolved at runtime so this doesn't go stale.
-      - name: Install Boost.Test (from source, trunk)
-        if: matrix.trunk
+      # Build the latest Boost release from source with the same compiler as
+      # the tests, so the whole binary is produced by one toolchain (prebuilt
+      # distro packages are both ancient and compiled by an older GCC, which
+      # broke Boost.Test's runtime parameter registration on the trunk leg).
+      # The version is resolved via the GitHub API so this doesn't go stale;
+      # the token avoids anonymous rate limits on shared runner IPs.
+      - name: Install Boost.Test (from source)
         run: |
-          boost_tag=$(curl -fsSL https://api.github.com/repos/boostorg/boost/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
+          boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/boostorg/boost/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
           boost_ver=${boost_tag#boost-}
           wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
           tar xzf boost.tar.gz
           cd "boost-${boost_ver}"
-          echo "using gcc : trunk : ${{ matrix.cxx }} ;" > user-config.jam
+          echo "using gcc : ci : ${{ matrix.cxx }} ;" > user-config.jam
           ./bootstrap.sh --prefix=/opt/boost-latest --with-libraries=test
-          ./b2 install -j"$(nproc)" --prefix=/opt/boost-latest --user-config=user-config.jam toolset=gcc-trunk variant=release link=static threading=multi
-          echo "BOOST_ROOT=/opt/boost-latest" >> "$GITHUB_ENV"
+          ./b2 install -j"$(nproc)" --prefix=/opt/boost-latest --user-config=user-config.jam toolset=gcc-ci variant=release link=static threading=multi
 
       - name: Configure
         run: >
           cmake -S . -B build
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
-          ${{ matrix.trunk && '-DCMAKE_PREFIX_PATH=/opt/boost-latest -DBoost_NO_SYSTEM_PATHS=ON' || '' }}
+          -DCMAKE_PREFIX_PATH=/opt/boost-latest
+          -DBoost_NO_SYSTEM_PATHS=ON
 
       - name: Build
         run: cmake --build build -v

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -79,7 +79,9 @@ jobs:
       # the token avoids anonymous rate limits on shared runner IPs.
       - name: Install Boost.Test (from source)
         run: |
-          boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" https://api.github.com/repos/boostorg/boost/releases/latest | grep -m1 '"tag_name"' | cut -d'"' -f4)
+          # /releases/latest can return a beta (boostorg doesn't always flag
+          # them as prerelease), so list releases and keep strict boost-X.Y.Z
+          boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/boostorg/boost/releases?per_page=20" | grep '"tag_name"' | cut -d'"' -f4 | grep -E -m1 '^boost-[0-9]+\.[0-9]+\.[0-9]+$')
           boost_ver=${boost_tag#boost-}
           wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
           tar xzf boost.tar.gz

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -99,9 +99,27 @@ jobs:
           Write-Host "Default toolset: $default; newest (preview) toolset: $newest"
           echo "VC_PREVIEW_TOOLSET=$newest" >> $env:GITHUB_ENV
 
-      - name: Install Boost.Test
+      # Build the latest Boost release from source with MSVC instead of
+      # taking vcpkg's prebuilt/pinned version. The version is resolved via
+      # the GitHub API so this doesn't go stale; the token avoids anonymous
+      # rate limits on shared runner IPs. On the preview leg Boost is built
+      # with the default (stable) MSVC toolset while the tests use the
+      # preview one - fine, since MSVC guarantees binary compatibility
+      # across toolset versions since VS 2015.
+      - name: Install Boost.Test (from source)
         shell: pwsh
-        run: vcpkg install boost-test:x64-windows
+        run: |
+          $headers = @{ Authorization = "Bearer ${{ github.token }}" }
+          $release = Invoke-RestMethod -Uri https://api.github.com/repos/boostorg/boost/releases/latest -Headers $headers
+          $tag = $release.tag_name
+          $ver = $tag -replace '^boost-', ''
+          Invoke-WebRequest -Uri "https://github.com/boostorg/boost/releases/download/$tag/boost-$ver-b2-nodocs.tar.gz" -OutFile boost.tar.gz
+          tar -xzf boost.tar.gz
+          cd "boost-$ver"
+          .\bootstrap.bat
+          if ($LASTEXITCODE -ne 0) { exit 1 }
+          .\b2 install --prefix=C:\boost-latest --with-test toolset=msvc address-model=64 variant=release link=static threading=multi
+          if ($LASTEXITCODE -ne 0) { exit 1 }
 
       - name: Configure
         if: "!matrix.preview_channel"
@@ -110,7 +128,8 @@ jobs:
           cmake -S . -B build
           -G "${{ matrix.generator }}" -A x64
           -T ${{ matrix.toolset }}
-          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          -DCMAKE_PREFIX_PATH=C:/boost-latest
+          -DBoost_NO_SYSTEM_PATHS=ON
 
       - name: Configure (preview toolset)
         if: matrix.preview_channel
@@ -119,7 +138,8 @@ jobs:
           cmake -S . -B build
           -G "${{ matrix.generator }}" -A x64
           -T "version=$env:VC_PREVIEW_TOOLSET,host=x64"
-          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          -DCMAKE_PREFIX_PATH=C:/boost-latest
+          -DBoost_NO_SYSTEM_PATHS=ON
 
       - name: Build
         shell: pwsh

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -110,7 +110,10 @@ jobs:
         shell: pwsh
         run: |
           $headers = @{ Authorization = "Bearer ${{ github.token }}" }
-          $release = Invoke-RestMethod -Uri https://api.github.com/repos/boostorg/boost/releases/latest -Headers $headers
+          # /releases/latest can return a beta (boostorg doesn't always flag
+          # them as prerelease), so list releases and keep strict boost-X.Y.Z
+          $release = (Invoke-RestMethod -Uri "https://api.github.com/repos/boostorg/boost/releases?per_page=20" -Headers $headers) |
+            Where-Object { $_.tag_name -match '^boost-\d+\.\d+\.\d+$' } | Select-Object -First 1
           $tag = $release.tag_name
           $ver = $tag -replace '^boost-', ''
           Invoke-WebRequest -Uri "https://github.com/boostorg/boost/releases/download/$tag/boost-$ver-b2-nodocs.tar.gz" -OutFile boost.tar.gz


### PR DESCRIPTION
## Summary

- Every CI leg now downloads and compiles the **latest Boost release** from source, instead of using prebuilt packages (apt's `libboost-test-dev` 1.74 on Linux, vcpkg's pinned `boost-test` on Windows).
- Each leg builds Boost with **its own toolchain**, so the whole test binary is produced by one compiler:
  - GCC legs: `using gcc : ci : g++-N` via a b2 user-config (generalizes the fix that already de-flaked the GCC trunk leg's ABI mismatch)
  - Clang legs: `using clang : ci : clang++-N`
  - MSVC legs: `toolset=msvc` (the preview leg links Boost built with the stable toolset — safe, since MSVC guarantees binary compatibility across toolset versions since VS 2015)
  - clang-cl leg: `toolset=clang-win` (clang-cl itself)
- The Boost version is resolved at run time via the GitHub releases API, authenticated with the workflow token to avoid anonymous rate limits on shared runner IPs — nothing hardcoded, nothing to go stale.
- CMake finds the self-built Boost via `CMAKE_PREFIX_PATH` + `Boost_NO_SYSTEM_PATHS=ON` on all legs; the vcpkg toolchain file and the unused `triplet` matrix keys are removed.

## Test plan

- [ ] CI: GCC 15/16/17-SVN legs build Boost with their own g++ and pass.
- [ ] CI: Clang 21/22/23-SVN legs build Boost with their own clang++ and pass.
- [ ] CI: MSVC 2022/2026/2026-Preview legs build Boost with msvc and pass.
- [ ] CI: clang-cl leg builds Boost with clang-win and passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_