### PR TITLE
Bootstrap b2 with clang-win on runners where build.bat can't find VS

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -119,7 +119,21 @@ jobs:
           Invoke-WebRequest -Uri "https://github.com/boostorg/boost/releases/download/$tag/boost-$ver-b2-nodocs.tar.gz" -OutFile boost.tar.gz
           tar -xzf boost.tar.gz
           cd "boost-$ver"
-          .\bootstrap.bat
+
+          # b2's engine bootstrap (build.bat) doesn't recognize VS 2026 yet
+          # ("Unknown toolset: vcunk" on the windows-2025 image; its support
+          # ends at vc143), but it does support clang-win, and every VS
+          # install bundles clang-cl. Put the bundled LLVM on PATH and
+          # bootstrap the b2 engine with it; the Boost libraries themselves
+          # are still built with toolset=msvc below.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $clangcl = & $vswhere -latest -products * -find 'VC\Tools\Llvm\x64\bin\clang-cl.exe' | Select-Object -First 1
+          if (-not $clangcl) {
+            Write-Host "clang-cl.exe not found via vswhere"
+            exit 1
+          }
+          $env:PATH = (Split-Path $clangcl) + ";" + $env:PATH
+          .\bootstrap.bat clang-win
           if ($LASTEXITCODE -ne 0) { exit 1 }
           .\b2 install --prefix=C:\boost-latest --with-test toolset=msvc address-model=64 variant=release link=static threading=multi
           if ($LASTEXITCODE -ne 0) { exit 1 }


### PR DESCRIPTION
## Summary

- Follow-up to #45: the MSVC 2026 and 2026-Preview legs fail at Boost's `bootstrap.bat` with `Unknown toolset: vcunk`. The b2 engine bootstrap (`build.bat`) finds the VS 18 installation via vswhere but doesn't know that version — its supported toolset list ends at `vc143` (VS 2022) — so the b2 engine never gets built on the windows-2025 image. This blocks the stable MSVC 2026 leg on master.
- `build.bat` does support `clang-win`, and every Visual Studio installation bundles clang-cl under `VC\Tools\Llvm`. Discover it via vswhere, prepend it to `PATH`, and bootstrap the b2 engine with `clang-win` instead of the broken auto-guess.
- This only changes how the b2 engine itself is compiled — the Boost libraries are still built with `toolset=msvc` exactly as before, so the toolchain-matching goal of #45 is unchanged.
- The MSVC 2022 leg (windows-2022, where the auto-guess finds `vc143` fine) also switches to the clang-win bootstrap for uniformity; the resulting b2 engine behaves identically.

## Test plan

- [ ] CI: MSVC 2022, 2026, and 2026-Preview legs get past `bootstrap.bat`, build Boost.Test with `toolset=msvc`, and pass.
- [ ] CI: clang-cl leg (untouched here) still builds Boost with the pinned VS-bundled clang-cl.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_