### PR TITLE
Use vcpkg everywhere for recent Boost, with GH Actions caching

### DIFF
--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -29,46 +29,14 @@ jobs:
           - generator: "Visual Studio 17 2022"
             toolset: "ClangCL,host=x64"
             arch: x64
+            triplet: x64-windows
 
     steps:
       - uses: actions/checkout@v4
 
-      # Build the latest Boost release from source with clang-cl itself
-      # (b2's clang-win toolset), so the whole binary is produced by one
-      # toolchain instead of taking vcpkg's prebuilt/pinned version. The
-      # version is resolved via the GitHub API so this doesn't go stale;
-      # the token avoids anonymous rate limits on shared runner IPs.
-      - name: Install Boost.Test (from source)
+      - name: Install Boost.Test
         shell: pwsh
-        run: |
-          $headers = @{ Authorization = "Bearer ${{ github.token }}" }
-          # /releases/latest can return a beta (boostorg doesn't always flag
-          # them as prerelease), so list releases and keep strict boost-X.Y.Z
-          $release = (Invoke-RestMethod -Uri "https://api.github.com/repos/boostorg/boost/releases?per_page=20" -Headers $headers) |
-            Where-Object { $_.tag_name -match '^boost-\d+\.\d+\.\d+$' } | Select-Object -First 1
-          $tag = $release.tag_name
-          $ver = $tag -replace '^boost-', ''
-          Invoke-WebRequest -Uri "https://github.com/boostorg/boost/releases/download/$tag/boost-$ver-b2-nodocs.tar.gz" -OutFile boost.tar.gz
-          tar -xzf boost.tar.gz
-          cd "boost-$ver"
-
-          # CMake's ClangCL toolset uses the clang-cl bundled with Visual
-          # Studio, but PATH has a newer standalone LLVM; if b2 picks up the
-          # latter, BoostConfig rejects the libs over the compiler-version
-          # tag in their names (clangw20 vs clangw19). Pin b2 to the exact
-          # same clang-cl binary the VS toolset will use.
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $clangcl = & $vswhere -latest -products * -find 'VC\Tools\Llvm\x64\bin\clang-cl.exe' | Select-Object -First 1
-          if (-not $clangcl) {
-            Write-Host "clang-cl.exe not found via vswhere"
-            exit 1
-          }
-          "using clang-win : : `"$($clangcl -replace '\\', '/')`" ;" | Set-Content user-config.jam
-
-          .\bootstrap.bat
-          if ($LASTEXITCODE -ne 0) { exit 1 }
-          .\b2 install --prefix=C:\boost-latest --user-config=user-config.jam --with-test toolset=clang-win address-model=64 variant=release link=static threading=multi
-          if ($LASTEXITCODE -ne 0) { exit 1 }
+        run: vcpkg install boost-test:${{ matrix.triplet }}
 
       - name: Configure
         shell: pwsh
@@ -76,8 +44,7 @@ jobs:
           cmake -S . -B build
           -G "${{ matrix.generator }}" -A ${{ matrix.arch }}
           -T ${{ matrix.toolset }}
-          -DCMAKE_PREFIX_PATH=C:/boost-latest
-          -DBoost_NO_SYSTEM_PATHS=ON
+          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build
         shell: pwsh

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -34,8 +34,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Export the two env vars vcpkg's "x-gha" binary source needs to talk
+      # to the GitHub Actions cache service, so built packages are reused
+      # across runs instead of recompiled from scratch every time.
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
       - name: Install Boost.Test
         shell: pwsh
+        env:
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         run: vcpkg install boost-test:${{ matrix.triplet }}
 
       - name: Configure

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -46,18 +46,32 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.version }}
 
-      # Unlike GCC's trunk snapshot, apt.llvm.org's Clang packages (including
-      # the dev/SVN build) link against the system libstdc++ like every other
-      # apt-installed compiler - no separate bundled runtime, so no ABI
-      # mismatch with the distro's prebuilt Boost.Test.
+      # Export the two env vars vcpkg's "x-gha" binary source needs to talk
+      # to the GitHub Actions cache service, so built packages are reused
+      # across runs instead of recompiled from scratch every time.
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      # Ubuntu 22.04's libboost-test-dev is Boost 1.74 (2020); vcpkg tracks
+      # recent Boost releases instead. apt.llvm.org's Clang packages
+      # (including the dev/SVN build) link against the system libstdc++ like
+      # every other apt-installed compiler on the runner - no separate
+      # bundled runtime, so no ABI mismatch with vcpkg's Boost.Test either.
       - name: Install Boost.Test
-        run: sudo apt-get install -y libboost-test-dev
+        env:
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+        run: vcpkg install boost-test:x64-linux
 
       - name: Configure
         run: >
           cmake -S . -B build
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+          -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
 
       - name: Build
         run: cmake --build build -v

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -46,31 +46,18 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.version }}
 
-      # Build the latest Boost release from source with the same compiler as
-      # the tests, so the whole binary is produced by one toolchain (the
-      # distro's libboost-test is both ancient and compiled by an older GCC).
-      # The version is resolved via the GitHub API so this doesn't go stale;
-      # the token avoids anonymous rate limits on shared runner IPs.
-      - name: Install Boost.Test (from source)
-        run: |
-          # /releases/latest can return a beta (boostorg doesn't always flag
-          # them as prerelease), so list releases and keep strict boost-X.Y.Z
-          boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/boostorg/boost/releases?per_page=20" | grep '"tag_name"' | cut -d'"' -f4 | grep -E -m1 '^boost-[0-9]+\.[0-9]+\.[0-9]+$')
-          boost_ver=${boost_tag#boost-}
-          wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
-          tar xzf boost.tar.gz
-          cd "boost-${boost_ver}"
-          echo "using clang : ci : ${{ matrix.cxx }} ;" > user-config.jam
-          ./bootstrap.sh --prefix=/opt/boost-latest --with-libraries=test
-          ./b2 install -j"$(nproc)" --prefix=/opt/boost-latest --user-config=user-config.jam toolset=clang-ci variant=release link=static threading=multi
+      # Unlike GCC's trunk snapshot, apt.llvm.org's Clang packages (including
+      # the dev/SVN build) link against the system libstdc++ like every other
+      # apt-installed compiler - no separate bundled runtime, so no ABI
+      # mismatch with the distro's prebuilt Boost.Test.
+      - name: Install Boost.Test
+        run: sudo apt-get install -y libboost-test-dev
 
       - name: Configure
         run: >
           cmake -S . -B build
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
-          -DCMAKE_PREFIX_PATH=/opt/boost-latest
-          -DBoost_NO_SYSTEM_PATHS=ON
 
       - name: Build
         run: cmake --build build -v

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -50,8 +50,12 @@ jobs:
       # Best-effort: installs Jonathan Wakely's binary snapshot of GCC trunk
       # (see https://jwakely.github.io/pkg-gcc-latest/). Not an official GCC
       # release, so this leg is allowed to fail (see continue-on-error above).
+      # The version banner includes the snapshot's build date, which we use
+      # below to key the Boost cache so it invalidates whenever the snapshot
+      # actually changes.
       - name: Install GCC trunk snapshot
         if: matrix.trunk
+        id: gcc-trunk
         run: |
           wget -q https://kayari.org/gcc-latest/gcc-latest.deb -O gcc-latest.deb
           sudo dpkg -i gcc-latest.deb || sudo apt-get install -f -y
@@ -70,25 +74,60 @@ jobs:
           sudo ldconfig
           ${{ matrix.cc }} --version
           ${{ matrix.cxx }} --version
+          echo "version=$(${{ matrix.cxx }} --version | head -1)" >> "$GITHUB_OUTPUT"
 
+      # Export the two env vars vcpkg's "x-gha" binary source needs to talk
+      # to the GitHub Actions cache service, so built packages are reused
+      # across runs instead of recompiled from scratch every time.
+      - name: Export GitHub Actions cache environment variables
+        if: "!matrix.trunk"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      # Ubuntu 22.04's libboost-test-dev is Boost 1.74 (2020); vcpkg tracks
+      # recent Boost releases instead. All apt-installed GCCs share the
+      # system libstdc++, so ABI is consistent regardless of which one built
+      # vcpkg's Boost.
       - name: Install Boost.Test (stable)
         if: "!matrix.trunk"
-        run: sudo apt-get install -y libboost-test-dev
+        env:
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+        run: vcpkg install boost-test:x64-linux
 
-      # The distro's libboost-test is a prebuilt static archive compiled by an
-      # older, ABI-stable GCC. Linking it against the trunk snapshot breaks
+      # The distro's/vcpkg's prebuilt Boost.Test is compiled by an older,
+      # ABI-stable GCC. Linking it against the trunk snapshot breaks
       # Boost.Test's runtime parameter registration ("Test setup error:
       # Parameter catch_system_errors"), because the snapshot ships its own,
       # newer libstdc++ (unlike apt-installed compilers, which all share the
       # system one). Building Boost.Test from source with the same trunk
-      # compiler avoids the mismatch. Version is resolved via the GitHub API
-      # so this doesn't go stale; the token avoids anonymous rate limits.
-      - name: Install Boost.Test (from source, trunk)
+      # compiler avoids the mismatch. The Boost version is resolved via the
+      # GitHub API so this doesn't go stale; the resulting build is cached
+      # (keyed on the exact trunk snapshot + Boost version) since a rebuild
+      # otherwise costs several minutes on every run.
+      - name: Resolve latest Boost version
         if: matrix.trunk
+        id: boost-version
         run: |
           # /releases/latest can return a beta (boostorg doesn't always flag
           # them as prerelease), so list releases and keep strict boost-X.Y.Z
           boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/boostorg/boost/releases?per_page=20" | grep '"tag_name"' | cut -d'"' -f4 | grep -E -m1 '^boost-[0-9]+\.[0-9]+\.[0-9]+$')
+          echo "tag=$boost_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Boost (trunk)
+        if: matrix.trunk
+        id: cache-boost-trunk
+        uses: actions/cache@v4
+        with:
+          path: /opt/boost-latest
+          key: boost-trunk-${{ runner.os }}-${{ steps.gcc-trunk.outputs.version }}-${{ steps.boost-version.outputs.tag }}
+
+      - name: Install Boost.Test (from source, trunk)
+        if: matrix.trunk && steps.cache-boost-trunk.outputs.cache-hit != 'true'
+        run: |
+          boost_tag=${{ steps.boost-version.outputs.tag }}
           boost_ver=${boost_tag#boost-}
           wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
           tar xzf boost.tar.gz
@@ -97,12 +136,22 @@ jobs:
           ./bootstrap.sh --prefix=/opt/boost-latest --with-libraries=test
           ./b2 install -j"$(nproc)" --prefix=/opt/boost-latest --user-config=user-config.jam toolset=gcc-trunk variant=release link=static threading=multi
 
-      - name: Configure
+      - name: Configure (stable)
+        if: "!matrix.trunk"
         run: >
           cmake -S . -B build
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
-          ${{ matrix.trunk && '-DCMAKE_PREFIX_PATH=/opt/boost-latest -DBoost_NO_SYSTEM_PATHS=ON' || '' }}
+          -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+
+      - name: Configure (trunk)
+        if: matrix.trunk
+        run: >
+          cmake -S . -B build
+          -DCMAKE_C_COMPILER=${{ matrix.cc }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+          -DCMAKE_PREFIX_PATH=/opt/boost-latest
+          -DBoost_NO_SYSTEM_PATHS=ON
 
       - name: Build
         run: cmake --build build -v

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -71,13 +71,20 @@ jobs:
           ${{ matrix.cc }} --version
           ${{ matrix.cxx }} --version
 
-      # Build the latest Boost release from source with the same compiler as
-      # the tests, so the whole binary is produced by one toolchain (prebuilt
-      # distro packages are both ancient and compiled by an older GCC, which
-      # broke Boost.Test's runtime parameter registration on the trunk leg).
-      # The version is resolved via the GitHub API so this doesn't go stale;
-      # the token avoids anonymous rate limits on shared runner IPs.
-      - name: Install Boost.Test (from source)
+      - name: Install Boost.Test (stable)
+        if: "!matrix.trunk"
+        run: sudo apt-get install -y libboost-test-dev
+
+      # The distro's libboost-test is a prebuilt static archive compiled by an
+      # older, ABI-stable GCC. Linking it against the trunk snapshot breaks
+      # Boost.Test's runtime parameter registration ("Test setup error:
+      # Parameter catch_system_errors"), because the snapshot ships its own,
+      # newer libstdc++ (unlike apt-installed compilers, which all share the
+      # system one). Building Boost.Test from source with the same trunk
+      # compiler avoids the mismatch. Version is resolved via the GitHub API
+      # so this doesn't go stale; the token avoids anonymous rate limits.
+      - name: Install Boost.Test (from source, trunk)
+        if: matrix.trunk
         run: |
           # /releases/latest can return a beta (boostorg doesn't always flag
           # them as prerelease), so list releases and keep strict boost-X.Y.Z
@@ -86,17 +93,16 @@ jobs:
           wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
           tar xzf boost.tar.gz
           cd "boost-${boost_ver}"
-          echo "using gcc : ci : ${{ matrix.cxx }} ;" > user-config.jam
+          echo "using gcc : trunk : ${{ matrix.cxx }} ;" > user-config.jam
           ./bootstrap.sh --prefix=/opt/boost-latest --with-libraries=test
-          ./b2 install -j"$(nproc)" --prefix=/opt/boost-latest --user-config=user-config.jam toolset=gcc-ci variant=release link=static threading=multi
+          ./b2 install -j"$(nproc)" --prefix=/opt/boost-latest --user-config=user-config.jam toolset=gcc-trunk variant=release link=static threading=multi
 
       - name: Configure
         run: >
           cmake -S . -B build
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
-          -DCMAKE_PREFIX_PATH=/opt/boost-latest
-          -DBoost_NO_SYSTEM_PATHS=ON
+          ${{ matrix.trunk && '-DCMAKE_PREFIX_PATH=/opt/boost-latest -DBoost_NO_SYSTEM_PATHS=ON' || '' }}
 
       - name: Build
         run: cmake --build build -v

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -99,44 +99,13 @@ jobs:
           Write-Host "Default toolset: $default; newest (preview) toolset: $newest"
           echo "VC_PREVIEW_TOOLSET=$newest" >> $env:GITHUB_ENV
 
-      # Build the latest Boost release from source with MSVC instead of
-      # taking vcpkg's prebuilt/pinned version. The version is resolved via
-      # the GitHub API so this doesn't go stale; the token avoids anonymous
-      # rate limits on shared runner IPs. On the preview leg Boost is built
-      # with the default (stable) MSVC toolset while the tests use the
-      # preview one - fine, since MSVC guarantees binary compatibility
-      # across toolset versions since VS 2015.
-      - name: Install Boost.Test (from source)
+      # MSVC guarantees binary compatibility across toolset versions since
+      # VS 2015, so vcpkg's Boost (built with the default/stable toolset)
+      # links fine against code compiled with the preview toolset too - no
+      # need to rebuild Boost itself from source for the preview leg.
+      - name: Install Boost.Test
         shell: pwsh
-        run: |
-          $headers = @{ Authorization = "Bearer ${{ github.token }}" }
-          # /releases/latest can return a beta (boostorg doesn't always flag
-          # them as prerelease), so list releases and keep strict boost-X.Y.Z
-          $release = (Invoke-RestMethod -Uri "https://api.github.com/repos/boostorg/boost/releases?per_page=20" -Headers $headers) |
-            Where-Object { $_.tag_name -match '^boost-\d+\.\d+\.\d+$' } | Select-Object -First 1
-          $tag = $release.tag_name
-          $ver = $tag -replace '^boost-', ''
-          Invoke-WebRequest -Uri "https://github.com/boostorg/boost/releases/download/$tag/boost-$ver-b2-nodocs.tar.gz" -OutFile boost.tar.gz
-          tar -xzf boost.tar.gz
-          cd "boost-$ver"
-
-          # b2's engine bootstrap (build.bat) doesn't recognize VS 2026 yet
-          # ("Unknown toolset: vcunk" on the windows-2025 image; its support
-          # ends at vc143), but it does support clang-win, and every VS
-          # install bundles clang-cl. Put the bundled LLVM on PATH and
-          # bootstrap the b2 engine with it; the Boost libraries themselves
-          # are still built with toolset=msvc below.
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $clangcl = & $vswhere -latest -products * -find 'VC\Tools\Llvm\x64\bin\clang-cl.exe' | Select-Object -First 1
-          if (-not $clangcl) {
-            Write-Host "clang-cl.exe not found via vswhere"
-            exit 1
-          }
-          $env:PATH = (Split-Path $clangcl) + ";" + $env:PATH
-          .\bootstrap.bat clang-win
-          if ($LASTEXITCODE -ne 0) { exit 1 }
-          .\b2 install --prefix=C:\boost-latest --with-test toolset=msvc address-model=64 variant=release link=static threading=multi
-          if ($LASTEXITCODE -ne 0) { exit 1 }
+        run: vcpkg install boost-test:x64-windows
 
       - name: Configure
         if: "!matrix.preview_channel"
@@ -145,8 +114,7 @@ jobs:
           cmake -S . -B build
           -G "${{ matrix.generator }}" -A x64
           -T ${{ matrix.toolset }}
-          -DCMAKE_PREFIX_PATH=C:/boost-latest
-          -DBoost_NO_SYSTEM_PATHS=ON
+          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
       - name: Configure (preview toolset)
         if: matrix.preview_channel
@@ -155,8 +123,7 @@ jobs:
           cmake -S . -B build
           -G "${{ matrix.generator }}" -A x64
           -T "version=$env:VC_PREVIEW_TOOLSET,host=x64"
-          -DCMAKE_PREFIX_PATH=C:/boost-latest
-          -DBoost_NO_SYSTEM_PATHS=ON
+          "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
       - name: Build
         shell: pwsh

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -99,12 +99,24 @@ jobs:
           Write-Host "Default toolset: $default; newest (preview) toolset: $newest"
           echo "VC_PREVIEW_TOOLSET=$newest" >> $env:GITHUB_ENV
 
+      # Export the two env vars vcpkg's "x-gha" binary source needs to talk
+      # to the GitHub Actions cache service, so built packages are reused
+      # across runs instead of recompiled from scratch every time.
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
       # MSVC guarantees binary compatibility across toolset versions since
       # VS 2015, so vcpkg's Boost (built with the default/stable toolset)
       # links fine against code compiled with the preview toolset too - no
       # need to rebuild Boost itself from source for the preview leg.
       - name: Install Boost.Test
         shell: pwsh
+        env:
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         run: vcpkg install boost-test:x64-windows
 
       - name: Configure


### PR DESCRIPTION
## Summary

- Every leg now gets a **recent** Boost release instead of ancient distro packages, via **vcpkg on every platform** (Linux, Windows) — one cross-platform tool instead of a from-source build per leg:
  - GCC 15/16: vcpkg (`x64-linux`) instead of apt's `libboost-test-dev` (Boost 1.74 from 2020).
  - Clang 21/22/23-SVN: vcpkg too — apt.llvm.org's Clang links against the system libstdc++ like every other apt-installed compiler, so no ABI concern even for the SVN build.
  - MSVC 2022/2026/2026-Preview, clang-cl: already vcpkg, unchanged.
  - GCC 17-SVN stays on the from-source b2 build — it's the one leg that's actually ABI-incompatible with any prebuilt Boost, since the trunk snapshot ships its own newer libstdc++.
- **GitHub Actions binary caching** wired up for every vcpkg leg via the official `x-gha` binary source (`ACTIONS_CACHE_URL`/`ACTIONS_RUNTIME_TOKEN` exported via `actions/github-script`), so vcpkg only builds each package once instead of on every CI run.
- The GCC-trunk from-source build is now wrapped in `actions/cache`, keyed on the exact snapshot version (captured from the compiler's own `--version` banner, which includes its build date) plus the resolved Boost tag — rebuilds only when either actually changes.

## Test plan

- [ ] CI: GCC 15/16 and all Clang legs pass with vcpkg's Boost; noticeably faster on cache hit.
- [ ] CI: GCC 17-SVN still passes with the from-source build; cache hit on a second run.
- [ ] CI: MSVC and clang-cl legs pass and benefit from vcpkg binary caching.
