### PR TITLE
Rename clang-cl row label, fix its bundled version to what's tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ These header-only libraries are continuously being tested with the following con
 | :------- | :------- | :------------ | :------------- | :---------------- | :---- |
 | Linux    | GCC      | 15             | 16              | 17-SVN             | [![GCC](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml) |
 | Linux    | Clang    | 21             | 22              | 23-SVN             | [![Clang](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml) |
-| Windows  | Clang (`clang-cl`) | —    | 20.1.8 (bundled) | —               | [![clang-cl](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml) |
+| Windows  | Clang-CL | —    | 19.1.5 (VS 2022, bundled) | —               | [![clang-cl](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml) |
 | Windows  | MSVC     | 2022           | 2026            | 2026-Preview       | [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml) |
 
 The `Trunk / Preview` column is allowed to fail independently and does not affect the badges above. The `clang-cl` leg tests Clang's diagnostics against the MSVC STL, using whichever LLVM version the Windows runner image bundles. MSVC has no stable `/std:c++23` switch yet, so both MSVC rows build with `/std:c++latest`.


### PR DESCRIPTION
## Summary

- Renamed the README's `Clang (`clang-cl`)` row label to `Clang-CL`.
- Fixed the version listed in that row: it said `20.1.8 (bundled)`, but the `clang-cl` leg only runs on `windows-2022`, and our own recent CI logs show it's actually Clang 19.1.5 there (`-- The CXX compiler identification is Clang 19.1.5 with MSVC-like command-line`). 20.1.8 turns out to be `windows-2025`/VS2026's bundled LLVM per [`actions/runner-images`'s own changelog](https://github.com/actions/runner-images/blob/win25-vs2026/20260628.158/images/windows/Windows2025-VS2026-Readme.md) — a runner this leg doesn't use.
- Investigated whether a distinct "VS2026-Preview" clang-cl version exists to report too: it doesn't. VS's Preview MSVC toolset is a separate, MSVC-only add-on component; "Clang tools for Windows" is a single shared VS component regardless of channel, so stable and preview would report the identical bundled Clang version even if we tested on `windows-2025`.

## Test plan

Documentation-only change, no CI-relevant files touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_