### PR TITLE
Test clang-cl on both VS 2022 and VS 2026

### DIFF
--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -17,16 +17,28 @@ jobs:
     # clang-cl: Clang's MSVC-compatible driver, using the MSVC STL and linker
     # rather than libc++. Exercises Clang's diagnostics (this repo builds
     # with -Weverything -Werror under Clang) against the same code MSVC
-    # builds, using whichever LLVM the runner image bundles. Best-effort:
-    # see continue-on-error below.
-    name: clang-cl (${{ matrix.arch }})
-    runs-on: windows-2022
+    # builds, using whichever LLVM each Visual Studio version bundles (19.1.5
+    # for VS 2022, 20.1.8 for VS 2026). There's no separate entry for the
+    # VS 2026 Preview channel: "Clang tools for Windows" is a single VS
+    # component shared by the stable and preview MSVC toolsets alike, so it'd
+    # be the exact same clang-cl.exe as the VS 2026 (stable) row - testing it
+    # again there would add no coverage. Best-effort: see continue-on-error.
+    name: clang-cl (${{ matrix.vs }})
+    runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
         include:
-          - generator: "Visual Studio 17 2022"
+          - vs: 2022
+            os: windows-2022
+            generator: "Visual Studio 17 2022"
+            toolset: "ClangCL,host=x64"
+            arch: x64
+            triplet: x64-windows
+          - vs: 2026
+            os: windows-2025
+            generator: "Visual Studio 18 2026"
             toolset: "ClangCL,host=x64"
             arch: x64
             triplet: x64-windows

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ These header-only libraries are continuously being tested with the following con
 | :------- | :------- | :------------ | :------------- | :---------------- | :---- |
 | Linux    | GCC      | 15             | 16              | 17-SVN             | [![GCC](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml) |
 | Linux    | Clang    | 21             | 22              | 23-SVN             | [![Clang](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml) |
-| Windows  | Clang-CL | —    | 19.1.5 (VS 2022, bundled) | —               | [![clang-cl](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml) |
+| Windows  | Clang-CL | 19.1.5 (VS 2022, bundled) | 20.1.8 (VS 2026, bundled) | —               | [![clang-cl](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml) |
 | Windows  | MSVC     | 2022           | 2026            | 2026-Preview       | [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml) |
 
-The `Trunk / Preview` column is allowed to fail independently and does not affect the badges above. The `clang-cl` leg tests Clang's diagnostics against the MSVC STL, using whichever LLVM version the Windows runner image bundles. MSVC has no stable `/std:c++23` switch yet, so both MSVC rows build with `/std:c++latest`.
+The `Trunk / Preview` column is allowed to fail independently and does not affect the badges above. The `clang-cl` leg tests Clang's diagnostics against the MSVC STL, using whichever LLVM version each Visual Studio version bundles; there's no separate `Trunk / Preview` entry for it, since "Clang tools for Windows" is a single VS component shared by the stable and preview MSVC toolsets alike. MSVC has no stable `/std:c++23` switch yet, so both MSVC rows build with `/std:c++latest`.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Split the single `clang-cl` leg into two matrix entries: VS 2022 (`windows-2022`, bundled Clang 19.1.5) and VS 2026 (`windows-2025`, bundled Clang 20.1.8) — both figures confirmed via `actions/runner-images`' own changelogs for those runner images.
- No third entry for the VS 2026 Preview channel: it only adds the `VC.Preview.Tools.x86.x64` MSVC-toolset component, while "Clang tools for Windows" is a single, separate VS component shared by the stable and preview MSVC toolsets alike — testing it again there would just rerun the identical `clang-cl.exe` with zero added coverage.
- Updated the README's Clang-CL row to show both real, CI-tested versions instead of a single figure with dashes on either side.

## Test plan

- [ ] CI: `clang-cl (2022)` passes on `windows-2022`.
- [ ] CI: `clang-cl (2026)` passes on `windows-2025`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_