### PR TITLE
Show "Clang-CL" as the badge/job label text

### DIFF
--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -3,7 +3,7 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
-name: clang-cl
+name: Clang-CL
 
 on:
   push:
@@ -23,7 +23,7 @@ jobs:
     # component shared by the stable and preview MSVC toolsets alike, so it'd
     # be the exact same clang-cl.exe as the VS 2026 (stable) row - testing it
     # again there would add no coverage. Best-effort: see continue-on-error.
-    name: clang-cl (${{ matrix.vs }})
+    name: Clang-CL (${{ matrix.vs }})
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-Boost-blue.svg)](https://opensource.org/licenses/BSL-1.0)
 [![GCC](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml)
 [![Clang](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml)
-[![clang-cl](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml)
+[![Clang-CL](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml)
 [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml)
 
 xstd is a header-only C++23 library for small standard-library extensions that can be implemented portably with stable compiler technology. It aims to prototype future-stdlib-style facilities without requiring experimental language features.
@@ -109,7 +109,7 @@ These header-only libraries are continuously being tested with the following con
 | :------- | :------- | :------------ | :------------- | :---------------- | :---- |
 | Linux    | GCC      | 15             | 16              | 17-SVN             | [![GCC](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml) |
 | Linux    | Clang    | 21             | 22              | 23-SVN             | [![Clang](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml) |
-| Windows  | Clang-CL | 19.1.5 (VS 2022, bundled) | 20.1.8 (VS 2026, bundled) | —               | [![clang-cl](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml) |
+| Windows  | Clang-CL | 19.1.5 (VS 2022, bundled) | 20.1.8 (VS 2026, bundled) | —               | [![Clang-CL](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml) |
 | Windows  | MSVC     | 2022           | 2026            | 2026-Preview       | [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml) |
 
 The `Trunk / Preview` column is allowed to fail independently and does not affect the badges above. The `clang-cl` leg tests Clang's diagnostics against the MSVC STL, using whichever LLVM version each Visual Studio version bundles; there's no separate `Trunk / Preview` entry for it, since "Clang tools for Windows" is a single VS component shared by the stable and preview MSVC toolsets alike. MSVC has no stable `/std:c++23` switch yet, so both MSVC rows build with `/std:c++latest`.


### PR DESCRIPTION
## Summary

- Renamed the workflow (and job) from `clang-cl` to `Clang-CL`, so the generated badge reads "Clang-CL" — matching the other workflows' Title Case badges (GCC, Clang, MSVC). The `.yml` filename and badge URL are unchanged.
- Updated the README's badge alt text to match.

## Test plan

Cosmetic rename only, no build-relevant changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_