### PR TITLE
Code review round: packaging, test coverage, and hygiene fixes

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -158,3 +158,34 @@ jobs:
 
       - name: Test
         run: ctest --test-dir build --output-on-failure
+
+      # Verify the install rules and that a downstream consumer can locate
+      # the installed package via find_package(xstd CONFIG). Once per
+      # matrix (on the latest stable leg) is enough: the install/consume
+      # path is compiler-independent.
+      - name: Install (package smoke test)
+        if: matrix.version == 16
+        run: cmake --install build --prefix "$GITHUB_WORKSPACE/xstd-prefix"
+
+      - name: Consume installed package
+        if: matrix.version == 16
+        run: |
+          mkdir consumer
+          cd consumer
+          cat > CMakeLists.txt << 'EOF'
+          cmake_minimum_required(VERSION 3.28)
+          project(consumer LANGUAGES CXX)
+          find_package(xstd 0.1 CONFIG REQUIRED)
+          add_executable(main main.cpp)
+          target_link_libraries(main PRIVATE xstd::xstd)
+          EOF
+          cat > main.cpp << 'EOF'
+          #include <xstd/cstdlib.hpp>
+          static_assert(xstd::euclidean_div(-8, 3).rem == 1);
+          int main() {}
+          EOF
+          cmake -S . -B build \
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
+            -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/xstd-prefix"
+          cmake --build build -v
+          ./build/main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,3 +61,24 @@ install(
     NAMESPACE ${PROJECT_NAME}::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
+
+# Package config + version files, so consumers can locate the installed
+# package with find_package(xstd CONFIG). ARCH_INDEPENDENT because a
+# header-only library has no architecture-specific binaries.
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    cmake/${PROJECT_NAME}Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    COMPATIBILITY SameMajorVersion
+    ARCH_INDEPENDENT
+)
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cmake --build build
 ctest --test-dir build --output-on-failure
 ```
 
-Tests require Boost.UnitTest.
+Tests require Boost.Test.
 
 ## Project layout
 

--- a/cmake/xstdConfig.cmake.in
+++ b/cmake/xstdConfig.cmake.in
@@ -1,0 +1,10 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/xstdTargets.cmake")
+
+check_required_components(xstd)

--- a/include/xstd/array.hpp
+++ b/include/xstd/array.hpp
@@ -6,7 +6,6 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <array>        // array
-#include <type_traits>  // conditional_t
 
 namespace xstd {
 

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -6,9 +6,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <cassert>      // assert
-#include <cstddef>      // size_t
 #include <iosfwd>       // basic_istream, basic_ostream
-#include <tuple>        // tie
 #include <type_traits>  // is_arithmetic_v
 
 #if defined(__clang__)
@@ -74,7 +72,7 @@ auto& operator>>(std::basic_istream<CharT, Traits>& istr XSTD_LIFETIMEBOUND, div
         auto const rT = numer % denom;
         assert(numer == denom * qT + rT);
         assert(abs(rT) < abs(denom));
-        assert(sign(rT) == sign(numer)|| rT == 0);
+        assert(sign(rT) == sign(numer) || rT == 0);
         return { qT, rT };
 }
 

--- a/include/xstd/type_traits.hpp
+++ b/include/xstd/type_traits.hpp
@@ -5,7 +5,7 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <compare>      // partial_ordering
+#include <compare>      // strong_ordering (tagged_empty's defaulted <=>)
 #include <type_traits>  // bool_constant, conditional_t, integral_constant
 
 namespace xstd {

--- a/test/src/array.cpp
+++ b/test/src/array.cpp
@@ -1,0 +1,45 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <xstd/array.hpp>               // array_from_types
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_CHECK_EQUAL
+#include <array>                        // array
+#include <cstddef>                      // size_t
+#include <tuple>                        // tuple
+#include <type_traits>                  // is_same_v
+
+using namespace xstd;
+
+BOOST_AUTO_TEST_SUITE(Array)
+
+template<class... T>
+struct type_list {};
+
+BOOST_AUTO_TEST_CASE(ArrayFromTypes)
+{
+        constexpr auto sizes = array_from_types<type_list<int, double, char>>()([](auto x) {
+                return sizeof(x);
+        });
+
+        static_assert(std::is_same_v<decltype(sizes), std::array<std::size_t, 3> const>);
+        static_assert(sizes == std::array{sizeof(int), sizeof(double), sizeof(char)});
+
+        BOOST_CHECK_EQUAL(sizes[0], sizeof(int));
+        BOOST_CHECK_EQUAL(sizes[1], sizeof(double));
+        BOOST_CHECK_EQUAL(sizes[2], sizeof(char));
+}
+
+BOOST_AUTO_TEST_CASE(WorksWithAnyTypeList)
+{
+        // any variadic class template works as the type list, e.g. std::tuple
+        auto const ones = array_from_types<std::tuple<bool, char>>()([](auto) {
+                return 1;
+        });
+        BOOST_CHECK_EQUAL(ones.size(), 2u);
+        BOOST_CHECK_EQUAL(ones[0], 1);
+        BOOST_CHECK_EQUAL(ones[1], 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -13,6 +13,14 @@
 #include <utility>                      // pair
 #include <vector>                       // vector
 
+// The whole point of these functions (p0533-style) is being usable in
+// constant expressions; verify that at compile time.
+static_assert(xstd::abs(-2) == 2);
+static_assert(xstd::sign(-2) == -1);
+static_assert(xstd::div(+8, +3) == xstd::div_t{+2, +2});
+static_assert(xstd::euclidean_div(-8, +3) == xstd::div_t{-3, +1});
+static_assert(xstd::floored_div(-8, +3) == xstd::div_t{-3, +1});
+
 BOOST_AUTO_TEST_SUITE(CStdLib)
 
 BOOST_AUTO_TEST_CASE(Abs)

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -3,10 +3,10 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <xstd/type_traits.hpp>         // is_specialization_of, is_integral_constant
+#include <xstd/type_traits.hpp>         // is_specialization_of, is_integral_constant, tagged_empty, optional_type
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_CHECK
 #include <complex>                      // complex
-#include <type_traits>                  // integral_constant
+#include <type_traits>                  // integral_constant, is_constructible_v, is_convertible_v, is_empty_v, is_same_v
 
 using namespace xstd;
 
@@ -35,6 +35,34 @@ BOOST_AUTO_TEST_CASE(IsIntegralConstant)
 
         BOOST_CHECK(( is_integral_constant_v<int_<0>, int>));
         BOOST_CHECK((!is_integral_constant_v<int,     int>));
+}
+
+struct tag1;
+struct tag2;
+
+BOOST_AUTO_TEST_CASE(TaggedEmpty)
+{
+        using empty1 = tagged_empty<tag1>;
+        using empty2 = tagged_empty<tag2>;
+
+        static_assert( std::is_empty_v<empty1>);
+        static_assert(!std::is_same_v<empty1, empty2>);
+
+        // constructible from anything, but only explicitly
+        static_assert( std::is_constructible_v<empty1, int, double>);
+        static_assert(!std::is_convertible_v<int, empty1>);
+
+        // stateless: all instances compare equal, regardless of construction
+        static_assert(empty1(1, 2.0) == empty1());
+        BOOST_CHECK(empty1() == empty1(42));
+}
+
+BOOST_AUTO_TEST_CASE(OptionalType)
+{
+        static_assert(std::is_same_v<optional_type<true,  tag1>, tag1>);
+        static_assert(std::is_same_v<optional_type<false, tag1>, tagged_empty<tag1>>);
+        static_assert(std::is_empty_v<optional_type<false, tag1>>);
+        BOOST_CHECK((std::is_same_v<optional_type<true, tag1>, tag1>));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -10,7 +10,7 @@
 
 using namespace xstd;
 
-BOOST_AUTO_TEST_SUITE(TypeTraits)
+BOOST_AUTO_TEST_SUITE(Utility)
 
 enum class e1 {};
 enum class e2 : bool {};


### PR DESCRIPTION
## Summary

Full-repo code review, all findings user-approved before implementation. Four commits:

**1. README fix** (original scope of this PR)
- "Boost.UnitTest" → "Boost.Test" — consistent with the rest of the README and the code.

**2. Hygiene**
- Removed unused includes: `<type_traits>` from `array.hpp`, `<cstddef>` and `<tuple>` from `cstdlib.hpp` (the latter a leftover from a pre-defaulted `operator==`).
- Fixed `type_traits.hpp`'s `<compare>` include comment: it's needed for `strong_ordering` (from `tagged_empty`'s defaulted `<=>`), not `partial_ordering`.
- Fixed a missing space before `||` in a `div` assert.

**3. Test coverage gaps**
- New `test/src/array.cpp`: `array_from_types` had *zero* coverage — the header wasn't even included by any test.
- New tests for `tagged_empty` (emptiness, tag distinctness, explicit-only construction from anything, stateless equality) and `optional_type` — both previously untested public API.
- Added `static_assert`s for `abs`/`sign`/`div`/`euclidean_div`/`floored_div`: constant-expression usability is these functions' entire raison d'être (p0533), but was only exercised at run time.
- Fixed copy-pasted suite name in `utility.cpp` (`TypeTraits` → `Utility`).

**4. Packaging: `find_package(xstd CONFIG)` now actually works**
- The install rules exported `xstdTargets.cmake` but installed no package config or version file, so `find_package(xstd)` failed for every consumer. Now generated via `CMakePackageConfigHelpers` (`ARCH_INDEPENDENT` for header-only) and installed alongside the targets file.
- New CI smoke test on the GCC 16 leg: `cmake --install` to a prefix, then configure/build/run a minimal downstream consumer using `find_package(xstd 0.1 CONFIG REQUIRED)` + `xstd::xstd`.

## Test plan

- [x] Local: GCC 13 and Clang 18 (`-Weverything -Werror`) build all 4 test binaries; 4/4 tests pass.
- [x] Local: install to a prefix produces `xstdConfig.cmake`/`xstdConfigVersion.cmake`/`xstdTargets.cmake`; downstream consumer configures, builds, and runs against it.
- [x] CI: all legs green; new "Install/Consume" steps pass on the GCC 16 leg.
