### PR TITLE
Fix dead C++23 draft link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ When adding or changing a public utility:
 
 ## Requirements
 
-These header-only libraries are continuously being tested with the following conforming [C++23](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/n4950.pdf) compilers. Following the model of [apt.llvm.org](https://apt.llvm.org/), we support the latest two stable releases of each compiler, plus its current development / preview branch, on a best-effort basis:
+These header-only libraries are continuously being tested with the following conforming [C++23](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/n4950.pdf) compilers. Following the model of [apt.llvm.org](https://apt.llvm.org/), we support the latest two stable releases of each compiler, plus its current development / preview branch, on a best-effort basis:
 
 | Platform | Compiler | Older stable | Latest stable | Trunk / Preview | Build |
 | :------- | :------- | :------------ | :------------- | :---------------- | :---- |


### PR DESCRIPTION
## Summary

- The README's Requirements section linked the C++23 reference to `open-std.org/.../papers/2022/n4950.pdf`, which 404s. [N4950](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/n4950.pdf) is the right document — the final working draft prior to C++23, dated 2023-05-10 — but it lives in the `papers/2023/` directory, not `papers/2022/`.

## Test plan

Documentation-only change; verified the corrected URL is the canonical WG21 location for N4950.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHniUiMwzubPp5TC52J5zj)_