### PR TITLE
Improve stream I/O for div_t and enhance test coverage

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,22 @@
+---
+# Static analysis for the public headers, run by the Clang-Tidy workflow
+# over the generated header self-sufficiency translation units (the
+# Boost.Test sources are excluded: test macros drown the signal in noise).
+Checks: >
+  bugprone-*,
+  clang-analyzer-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -misc-include-cleaner,
+  -misc-non-private-member-variables-in-classes,
+  -modernize-use-trailing-return-type,
+  -readability-avoid-nested-conditional-operator,
+  -readability-identifier-length,
+  -readability-named-parameter,
+  -readability-simplify-boolean-expr
+WarningsAsErrors: '*'
+HeaderFilterRegex: 'include/xstd/.*'
+FormatStyle: none

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/vcpkg/toolchains/libcxx.cmake
+++ b/.github/vcpkg/toolchains/libcxx.cmake
@@ -1,0 +1,13 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+# Chainloaded by the x64-linux-libcxx triplet: builds vcpkg ports with the
+# same Clang + libc++ combination the Clang workflow's libc++ leg uses for
+# xstd itself. Bump the compiler version together with the clang.yml matrix.
+set(CMAKE_C_COMPILER clang-22)
+set(CMAKE_CXX_COMPILER clang++-22)
+set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-stdlib=libc++")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-stdlib=libc++")

--- a/.github/vcpkg/triplets/x64-linux-libcxx.cmake
+++ b/.github/vcpkg/triplets/x64-linux-libcxx.cmake
@@ -1,0 +1,13 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+# x64-linux, but built with Clang against libc++ instead of the default
+# compiler against libstdc++. Used by the libc++ leg of the Clang workflow
+# so that vcpkg's Boost.Test and the xstd tests share one standard library.
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/../toolchains/libcxx.cmake)

--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -5,6 +5,13 @@
 
 name: Baseline
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -109,7 +109,9 @@ jobs:
           cat > CMakeLists.txt << 'CMAKE'
           cmake_minimum_required(VERSION 3.28)
           project(consumer_add_subdirectory LANGUAGES CXX)
-          set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+          # no BUILD_TESTING workaround: xstd only builds its tests (and
+          # requires Boost.Test) when it is the top-level project, which
+          # this consumer configure would fail on if that gating regressed
           add_subdirectory("$ENV{GITHUB_WORKSPACE}" xstd-build)
           add_executable(main main.cpp)
           target_link_libraries(main PRIVATE xstd::xstd)
@@ -149,7 +151,6 @@ jobs:
           cmake_minimum_required(VERSION 3.28)
           project(consumer_fetch_content LANGUAGES CXX)
           include(FetchContent)
-          set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
           FetchContent_Declare(xstd SOURCE_DIR "$ENV{GITHUB_WORKSPACE}")
           FetchContent_MakeAvailable(xstd)
           add_executable(main main.cpp)

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -5,6 +5,13 @@
 
 name: Clang-CL
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,70 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+name: Clang-Tidy
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  tidy:
+    name: clang-tidy 22
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Clang 22 and clang-tidy 22
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 22
+          sudo apt-get install -y clang-tidy-22
+
+      # Export the two env vars vcpkg's "x-gha" binary source needs to talk
+      # to the GitHub Actions cache service, so built packages are reused
+      # across runs instead of recompiled from scratch every time.
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      # Only needed so that the test tree (and with it the compile database
+      # entries below) configures; clang-tidy itself never links Boost.
+      - name: Install Boost.Test
+        env:
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+        run: vcpkg install --triplet x64-linux
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_C_COMPILER=clang-22
+          -DCMAKE_CXX_COMPILER=clang++-22
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+
+      # Analyze the public headers through the generated header
+      # self-sufficiency translation units. The Boost.Test sources are left
+      # out on purpose: the test macros drown the signal in noise. The
+      # check selection and per-check suppressions live in .clang-tidy;
+      # WarningsAsErrors there makes any finding fail this job.
+      - name: Run clang-tidy over the public headers
+        run: >
+          run-clang-tidy-22 -quiet -p build
+          "$GITHUB_WORKSPACE/build/test/header_self_sufficiency/.*"

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     name: Clang ${{ matrix.label }}
     runs-on: ubuntu-22.04
-    continue-on-error: ${{ matrix.trunk }}
+    continue-on-error: ${{ matrix.best_effort }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,17 +32,40 @@ jobs:
             version: 21
             cc: clang-21
             cxx: clang++-21
-            trunk: false
+            stdlib: libstdc++
+            triplet: x64-linux
+            cxxflags: ""
+            best_effort: false
           - label: "22"
             version: 22
             cc: clang-22
             cxx: clang++-22
-            trunk: false
+            stdlib: libstdc++
+            triplet: x64-linux
+            cxxflags: ""
+            best_effort: false
+          # The MSVC STL and libstdc++ are covered by the other workflows;
+          # this leg adds the third mainstream standard library. Boost.Test
+          # is rebuilt against libc++ through the overlay triplet in
+          # .github/vcpkg (a libstdc++ Boost would not link). Best-effort
+          # until the vcpkg overlay path has proven itself; promote it to a
+          # required leg (best_effort: false) once it is green on master.
+          - label: 22 libc++
+            version: 22
+            cc: clang-22
+            cxx: clang++-22
+            stdlib: libc++
+            triplet: x64-linux-libcxx
+            cxxflags: "-stdlib=libc++"
+            best_effort: true
           - label: 23-SVN
             version: 23
             cc: clang-23
             cxx: clang++-23
-            trunk: true
+            stdlib: libstdc++
+            triplet: x64-linux
+            cxxflags: ""
+            best_effort: true
 
     steps:
       - uses: actions/checkout@v4
@@ -52,6 +75,10 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.version }}
+
+      - name: Install libc++ ${{ matrix.version }}
+        if: matrix.stdlib == 'libc++'
+        run: sudo apt-get install -y libc++-${{ matrix.version }}-dev libc++abi-${{ matrix.version }}-dev
 
       # Export the two env vars vcpkg's "x-gha" binary source needs to talk
       # to the GitHub Actions cache service, so built packages are reused
@@ -68,17 +95,25 @@ jobs:
       # (including the dev/SVN build) link against the system libstdc++ like
       # every other apt-installed compiler on the runner - no separate
       # bundled runtime, so no ABI mismatch with vcpkg's Boost.Test either.
+      # The libc++ leg instead selects the overlay triplet, which rebuilds
+      # Boost.Test with Clang against libc++.
       - name: Install Boost.Test
         env:
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-        run: vcpkg install --triplet x64-linux
+        run: >
+          vcpkg install
+          --triplet ${{ matrix.triplet }}
+          --overlay-triplets "$GITHUB_WORKSPACE/.github/vcpkg/triplets"
 
       - name: Configure
         run: >
           cmake -S . -B build
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+          "-DCMAKE_CXX_FLAGS=${{ matrix.cxxflags }}"
           -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+          -DVCPKG_OVERLAY_TRIPLETS=$GITHUB_WORKSPACE/.github/vcpkg/triplets
 
       - name: Build
         run: cmake --build build -v

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -5,6 +5,13 @@
 
 name: Clang
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ name: Coverage
 
 permissions:
   contents: read
+  id-token: write   # tokenless Codecov upload via GitHub OIDC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -66,6 +67,8 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure
 
+      # The library is small enough that full line coverage of include/ is a
+      # realistic bar; --fail-under-line turns any regression into a red job.
       - name: Generate coverage report
         run: >
           gcovr --root .
@@ -73,9 +76,30 @@ jobs:
           --exclude 'test/.*'
           --exclude 'build/.*'
           --print-summary
-          --xml-pretty --output coverage.xml
+          --fail-under-line 100
+          --txt coverage.txt
+          --xml-pretty --xml coverage.xml
+
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          {
+            echo '### Line coverage (gcovr, include/ only)'
+            echo '```'
+            cat coverage.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          use_oidc: true
+          fail_ci_if_error: false
 
       - name: Upload coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,13 @@
 
 name: Coverage
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -5,6 +5,13 @@
 
 name: GCC
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -5,6 +5,13 @@
 
 name: MSVC
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -5,6 +5,13 @@
 
 name: Sanitizers
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,15 +19,9 @@ add_library(
 )
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-set(project_include_dir
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-target_include_directories(
-    ${PROJECT_NAME} INTERFACE
-    ${project_include_dir}
-)
-
+# No target_include_directories: the HEADERS file set below adds its base
+# directory to the build interface, and install(TARGETS ... FILE_SET) adds
+# the install destination to the install interface.
 target_compile_features(
     ${PROJECT_NAME} INTERFACE
     cxx_std_23

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,15 @@ target_sources(
         include/xstd/utility.hpp
 )
 
-include(CTest)
-
-if(BUILD_TESTING)
-    add_subdirectory(test)
+# Tests (and their Boost.Test dependency) only exist when xstd itself is
+# being developed. Consumers vendoring this directory via add_subdirectory
+# or FetchContent get just the header-only target, with no BUILD_TESTING
+# workaround required on their side.
+if(PROJECT_IS_TOP_LEVEL)
+    include(CTest)
+    if(BUILD_TESTING)
+        add_subdirectory(test)
+    endif()
 endif()
 
 install(

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,6 +7,11 @@
   },
   "configurePresets": [
     {
+      "name": "vcpkg",
+      "hidden": true,
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    },
+    {
       "name": "dev",
       "displayName": "Developer debug build",
       "binaryDir": "${sourceDir}/build/dev",
@@ -34,6 +39,18 @@
         "CMAKE_BUILD_TYPE": "Release",
         "BUILD_TESTING": "OFF"
       }
+    },
+    {
+      "name": "dev-vcpkg",
+      "displayName": "Developer debug build (Boost.Test via vcpkg, needs VCPKG_ROOT)",
+      "inherits": ["dev", "vcpkg"],
+      "binaryDir": "${sourceDir}/build/dev-vcpkg"
+    },
+    {
+      "name": "release-vcpkg",
+      "displayName": "Release build (Boost.Test via vcpkg, needs VCPKG_ROOT)",
+      "inherits": ["release", "vcpkg"],
+      "binaryDir": "${sourceDir}/build/release-vcpkg"
     }
   ],
   "buildPresets": [
@@ -48,6 +65,14 @@
     {
       "name": "no-tests",
       "configurePreset": "no-tests"
+    },
+    {
+      "name": "dev-vcpkg",
+      "configurePreset": "dev-vcpkg"
+    },
+    {
+      "name": "release-vcpkg",
+      "configurePreset": "release-vcpkg"
     }
   ],
   "testPresets": [
@@ -61,6 +86,20 @@
     {
       "name": "release",
       "configurePreset": "release",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "dev-vcpkg",
+      "configurePreset": "dev-vcpkg",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "release-vcpkg",
+      "configurePreset": "release-vcpkg",
       "output": {
         "outputOnFailure": true
       }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Clang](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml)
 [![Clang-CL](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml)
 [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml)
+[![Coverage](https://codecov.io/gh/rhalbersma/xstd/branch/master/graph/badge.svg)](https://codecov.io/gh/rhalbersma/xstd)
 
 xstd is a header-only C++23 library for small standard-library extensions that can be implemented portably with stable compiler technology. It aims to prototype future-stdlib-style facilities without requiring experimental language features.
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ These header-only libraries are continuously being tested with the following con
 
 The `Trunk / Preview` column is allowed to fail independently and does not affect the badges above. The `clang-cl` leg tests Clang's diagnostics against the MSVC STL, using whichever LLVM version each Visual Studio version bundles; there's no separate `Trunk / Preview` entry for it, since "Clang tools for Windows" is a single VS component shared by the stable and preview MSVC toolsets alike. The CMake target requests C++23 through `target_compile_features(... cxx_std_23)`, letting CMake select the appropriate standard flag for each supported compiler.
 
+All three mainstream standard libraries are exercised: libstdc++ (GCC and Clang legs), the MSVC STL (MSVC and Clang-CL legs), and libc++ (a best-effort `libc++` leg of the Clang workflow, which rebuilds Boost.Test against libc++ through the vcpkg overlay triplet in `.github/vcpkg`). macOS / AppleClang is currently not tested; the library is expected to work with any toolchain that implements the C++23 features above, including `std::format` for tuple-like types.
+
 ## License
 
 Copyright Rein Halbersma 2014-2026.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ auto const text = std::format("{}", floored); // "(-3, 1)"
 
 Formatting `xstd::div_t` requires C++23 standard-library support for formatting tuple-like values, because its formatter delegates to `std::formatter<std::tuple<int const&, int const&>>` through `std::tie`. This is covered by the continuously tested compiler and standard-library versions below.
 
-`xstd::abs` and `xstd::sign` accept arithmetic types; for unsigned inputs, `abs` is the identity, and for `bool`, `sign(true) == 1` while `sign(false) == 0`.
+`xstd::abs` and `xstd::sign` accept arithmetic types other than `bool`; for unsigned inputs, `abs` is the identity. Like the built-in unary minus, `abs` promotes integral types narrower than `int`, which makes it well-defined even for their most negative values. For `int` and wider signed integer types, the most negative value is outside `abs`'s contract (guarded by an `assert`), just like `INT_MIN / -1` is for the division helpers.
 
 ### Type traits
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ find_package(xstd 0.1 CONFIG REQUIRED)
 target_link_libraries(my_target PRIVATE xstd::xstd)
 ```
 
-When vendoring the repository as a subdirectory, disable tests unless you also want to build xstd's Boost.Test suite:
+When vendoring the repository as a subdirectory (xstd's own tests and their Boost.Test dependency are only built when xstd is the top-level project, so nothing needs to be disabled):
 
 ```cmake
-set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 add_subdirectory(external/xstd)
 target_link_libraries(my_target PRIVATE xstd::xstd)
 ```
@@ -43,7 +42,6 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/rhalbersma/xstd.git
     GIT_TAG master # or a release tag
 )
-set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(xstd)
 target_link_libraries(my_target PRIVATE xstd::xstd)
 ```

--- a/README.md
+++ b/README.md
@@ -122,11 +122,12 @@ cmake --build --preset dev
 ctest --preset dev
 ```
 
-Tests require Boost.Test. The checked-in vcpkg manifest declares that dependency for vcpkg-based builds:
+Tests require Boost.Test. The checked-in vcpkg manifest declares that dependency for vcpkg-based builds, and the `*-vcpkg` presets pick up the toolchain from the `VCPKG_ROOT` environment variable:
 
 ```sh
-vcpkg install --triplet x64-linux
-cmake --preset dev -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+cmake --preset dev-vcpkg
+cmake --build --preset dev-vcpkg
+ctest --preset dev-vcpkg
 ```
 
 Alternatively, install Boost.Test with your system package manager and point CMake at the package if it is not found automatically.

--- a/include/xstd/array.hpp
+++ b/include/xstd/array.hpp
@@ -16,7 +16,10 @@ struct array_from_types;
 template<template<class...> class L, class... T>
 struct array_from_types<L<T...>>
 {
+        // constrained to non-empty type lists: with no elements there is no
+        // type for std::array's class template argument deduction to deduce
         [[nodiscard]] constexpr auto operator()(auto fun) const noexcept((noexcept(fun(std::type_identity<T>())) && ...))
+                requires (sizeof...(T) > 0)
         {
                 return std::array{fun(std::type_identity<T>())...};
         }

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -7,6 +7,7 @@
 
 #include <cassert>      // assert
 #include <format>       // format, formatter
+#include <ios>          // ios_base
 #include <iosfwd>       // basic_istream, basic_ostream
 #include <limits>       // numeric_limits
 #include <tuple>        // tie, tuple
@@ -133,15 +134,28 @@ auto& operator<<(std::basic_ostream<wchar_t, Traits>& ostr, div_t const& d)
         return ostr << std::format(L"{}", d).c_str();
 }
 
+// Extracts a div_t from text of the form "(quot, rem)", as produced by
+// operator<< and std::format. Malformed input is a runtime condition, not a
+// contract violation, so - following the conventions of the standard
+// library's extractors - it sets failbit and leaves d unmodified.
 template<class CharT, class Traits>
 auto& operator>>(std::basic_istream<CharT, Traits>& istr, div_t& d)
 {
-        CharT c;
-        istr >> c; assert(c == istr.widen('('));
-        istr >> d.quot;
-        istr >> c; assert(c == istr.widen(','));
-        istr >> d.rem;
-        istr >> c; assert(c == istr.widen(')'));
+        auto const expect = [&istr](char token) {
+                auto c = CharT();
+                if (istr >> c && !Traits::eq(c, istr.widen(token))) {
+                        istr.setstate(std::ios_base::failbit);
+                }
+        };
+        auto parsed = div_t{};
+        expect('(');
+        istr >> parsed.quot;
+        expect(',');
+        istr >> parsed.rem;
+        expect(')');
+        if (istr) {
+                d = parsed;
+        }
         return istr;
 }
 

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -34,25 +34,6 @@ struct div_t
         bool operator==(div_t const&) const = default;
 };
 
-template<class CharT, class Traits>
-auto& operator<<(std::basic_ostream<CharT, Traits>& ostr, div_t const& d)
-{
-        ostr << std::format("({},{})", d.quot, d.rem);
-        return ostr;
-}
-
-template<class CharT, class Traits>
-auto& operator>>(std::basic_istream<CharT, Traits>& istr, div_t& d)
-{
-        CharT c;
-        istr >> c; assert(c == istr.widen('('));
-        istr >> d.quot;
-        istr >> c; assert(c == istr.widen(','));
-        istr >> d.rem;
-        istr >> c; assert(c == istr.widen(')'));
-        return istr;
-}
-
 namespace detail {
 
 [[nodiscard]] constexpr auto magnitude(int x) noexcept
@@ -132,3 +113,36 @@ struct std::formatter<xstd::div_t, CharT>
                 return std::formatter<std::tuple<int const&, int const&>, CharT>::format(std::tie(d.quot, d.rem), ctx);
         }
 };
+
+namespace xstd {
+
+// The stream inserters delegate to std::format (hence they are defined below
+// the formatter specialization), so that streaming and formatting a div_t
+// produce identical text. The .c_str() detour keeps them usable with any
+// Traits, which the basic_string inserter would reject.
+
+template<class Traits>
+auto& operator<<(std::basic_ostream<char, Traits>& ostr, div_t const& d)
+{
+        return ostr << std::format("{}", d).c_str();
+}
+
+template<class Traits>
+auto& operator<<(std::basic_ostream<wchar_t, Traits>& ostr, div_t const& d)
+{
+        return ostr << std::format(L"{}", d).c_str();
+}
+
+template<class CharT, class Traits>
+auto& operator>>(std::basic_istream<CharT, Traits>& istr, div_t& d)
+{
+        CharT c;
+        istr >> c; assert(c == istr.widen('('));
+        istr >> d.quot;
+        istr >> c; assert(c == istr.widen(','));
+        istr >> d.rem;
+        istr >> c; assert(c == istr.widen(')'));
+        return istr;
+}
+
+}       // namespace xstd

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -11,20 +11,26 @@
 #include <iosfwd>       // basic_istream, basic_ostream
 #include <limits>       // numeric_limits
 #include <tuple>        // tie, tuple
-#include <type_traits>  // is_arithmetic_v
+#include <type_traits>  // is_arithmetic_v, is_integral_v, is_same_v, is_signed_v
 
 namespace xstd {
 
+// a constexpr version of std::abs(int) (P0533). As with the built-in unary
+// minus, the result is promoted for integral types narrower than int, which
+// also makes abs(x) well-defined for their most negative values.
 template<class T>
 [[nodiscard]] constexpr auto abs(T const& x) noexcept
-        requires std::is_arithmetic_v<T>
+        requires (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>)
 {
+        if constexpr (std::is_integral_v<T> && std::is_signed_v<T> && std::is_same_v<decltype(-x), T>) {
+                assert(x != std::numeric_limits<T>::min());     // -x would overflow
+        }
         return x < 0 ? -x : x;
 }
 
 template<class T>
 [[nodiscard]] constexpr auto sign(T const& x) noexcept
-        requires std::is_arithmetic_v<T>
+        requires (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>)
 {
         return static_cast<int>(0 < x) - static_cast<int>(x < 0);
 }

--- a/include/xstd/type_traits.hpp
+++ b/include/xstd/type_traits.hpp
@@ -6,7 +6,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <compare>      // strong_ordering (tagged_empty's defaulted <=>)
-#include <type_traits>  // bool_constant, conditional_t, integral_constant
+#include <type_traits>  // bool_constant, conditional_t, integral_constant, is_same_v, remove_cvref_t
 
 namespace xstd {
 
@@ -32,7 +32,13 @@ template<class Tag>
 struct tagged_empty
 {
         tagged_empty() = default;
-        constexpr explicit tagged_empty(auto&&...) noexcept {}
+
+        // constrained so that this catch-all never hijacks copy or move
+        // construction from the (trivial) special member functions
+        template<class... Args>
+                requires (!(std::is_same_v<std::remove_cvref_t<Args>, tagged_empty> || ...))
+        constexpr explicit tagged_empty(Args&&...) noexcept {}
+
         auto operator<=>(tagged_empty const&) const = default;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,36 +3,6 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
-set(public_header_dir ${PROJECT_SOURCE_DIR}/include)
-file(
-    GLOB_RECURSE public_headers
-    CONFIGURE_DEPENDS
-    RELATIVE ${public_header_dir}
-    ${public_header_dir}/xstd/*.hpp
-)
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/header_self_sufficiency)
-
-foreach(h ${public_headers})
-    string(REPLACE "/" "." header_test_id ${h})
-    string(REGEX REPLACE "[.]hpp$" "" header_test_id ${header_test_id})
-    set(header_test_source ${CMAKE_CURRENT_BINARY_DIR}/header_self_sufficiency/${header_test_id}.cpp)
-    file(
-        WRITE ${header_test_source}
-        "#include <${h}>\nint main() {}\n"
-    )
-
-    add_executable(header.${header_test_id} ${header_test_source})
-    target_link_libraries(header.${header_test_id} PRIVATE ${PROJECT_NAME}::${PROJECT_NAME})
-    add_test(NAME header.${header_test_id} COMMAND header.${header_test_id})
-endforeach()
-
-set(Boost_USE_STATIC_LIBS ON)
-
-find_package(
-    Boost CONFIG REQUIRED COMPONENTS
-    unit_test_framework
-)
-
 add_library(xstd_test_options INTERFACE)
 option(XSTD_WARNINGS_AS_ERRORS "Treat warnings as errors in xstd tests" ${PROJECT_IS_TOP_LEVEL})
 
@@ -99,6 +69,42 @@ target_compile_options(
     ${cxx_compile_options_mbig_obj}
     $<$<AND:$<BOOL:${XSTD_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
     $<$<AND:$<BOOL:${XSTD_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>
+)
+
+# Each public header is compiled as its own translation unit (linked against
+# the same warning flags as the unit tests), proving it is self-sufficient.
+set(public_header_dir ${PROJECT_SOURCE_DIR}/include)
+file(
+    GLOB_RECURSE public_headers
+    CONFIGURE_DEPENDS
+    RELATIVE ${public_header_dir}
+    ${public_header_dir}/xstd/*.hpp
+)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/header_self_sufficiency)
+
+foreach(h ${public_headers})
+    string(REPLACE "/" "." header_test_id ${h})
+    string(REGEX REPLACE "[.]hpp$" "" header_test_id ${header_test_id})
+    set(header_test_source ${CMAKE_CURRENT_BINARY_DIR}/header_self_sufficiency/${header_test_id}.cpp)
+    file(
+        WRITE ${header_test_source}
+        "#include <${h}>\nint main() {}\n"
+    )
+
+    add_executable(header.${header_test_id} ${header_test_source})
+    target_link_libraries(
+        header.${header_test_id} PRIVATE
+        ${PROJECT_NAME}::${PROJECT_NAME}
+        xstd_test_options
+    )
+    add_test(NAME header.${header_test_id} COMMAND header.${header_test_id})
+endforeach()
+
+set(Boost_USE_STATIC_LIBS ON)
+
+find_package(
+    Boost CONFIG REQUIRED COMPONENTS
+    unit_test_framework
 )
 
 set(current_source_dir ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,9 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
+# strict -std=c++23 rather than the default gnu++23 dialect
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 add_library(xstd_test_options INTERFACE)
 option(XSTD_WARNINGS_AS_ERRORS "Treat warnings as errors in xstd tests" ${PROJECT_IS_TOP_LEVEL})
 
@@ -100,7 +103,9 @@ foreach(h ${public_headers})
     add_test(NAME header.${header_test_id} COMMAND header.${header_test_id})
 endforeach()
 
-set(Boost_USE_STATIC_LIBS ON)
+if(NOT DEFINED Boost_USE_STATIC_LIBS)
+    set(Boost_USE_STATIC_LIBS ON)
+endif()
 
 find_package(
     Boost CONFIG REQUIRED COMPONENTS
@@ -116,8 +121,8 @@ file(
 )
 
 foreach(t ${targets})
-    get_filename_component(target_path ${t} PATH)
-    get_filename_component(target_name_we ${t} NAME_WE)
+    cmake_path(GET t PARENT_PATH target_path)
+    cmake_path(GET t STEM target_name_we)
     string(REPLACE "/" "." target_id ${target_path}/${target_name_we})
     string(REGEX REPLACE "^[.]" "" target_id ${target_id})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,12 +56,6 @@ set(cxx_compile_options_warnings
     >
 )
 
-set(cxx_compile_options_mbig_obj
-    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>>:
-	    -Wa,-mbig-obj
-    >
-)
-
 target_compile_definitions(
     xstd_test_options INTERFACE
     ${cxx_compile_definitions}
@@ -69,7 +63,6 @@ target_compile_definitions(
 target_compile_options(
     xstd_test_options INTERFACE
     ${cxx_compile_options_warnings}
-    ${cxx_compile_options_mbig_obj}
     $<$<AND:$<BOOL:${XSTD_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
     $<$<AND:$<BOOL:${XSTD_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>
 )

--- a/test/src/array.cpp
+++ b/test/src/array.cpp
@@ -8,7 +8,7 @@
 #include <array>                        // array
 #include <cstddef>                      // size_t
 #include <tuple>                        // tuple
-#include <type_traits>                  // is_same_v
+#include <type_traits>                  // is_invocable_v, is_same_v
 
 using namespace xstd;
 
@@ -53,6 +53,16 @@ BOOST_AUTO_TEST_CASE(WorksWithNonDefaultConstructibleTypes)
                 return sizeof(T);
         });
         static_assert(sizes == std::array{sizeof(non_default_constructible)});
+}
+
+BOOST_AUTO_TEST_CASE(RequiresNonEmptyTypeList)
+{
+        // an empty type list leaves no type for std::array's CTAD to deduce,
+        // so the call operator's constraint rejects it up front
+        auto const fun = [](auto) { return 1; };
+        static_assert( std::is_invocable_v<array_from_types<type_list<int>>, decltype(fun)>);
+        static_assert(!std::is_invocable_v<array_from_types<type_list<>>,    decltype(fun)>);
+        BOOST_CHECK((!std::is_invocable_v<array_from_types<type_list<>>, decltype(fun)>));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -11,6 +11,7 @@
 #include <format>                       // format
 #include <iterator>                     // back_inserter
 #include <limits>                       // numeric_limits
+#include <sstream>                      // istringstream, ostringstream, stringstream, wostringstream
 #include <string>                       // string
 #include <utility>                      // pair
 #include <vector>                       // vector
@@ -173,6 +174,21 @@ BOOST_AUTO_TEST_CASE(Formatter)
         xstd::div_t const d { 1, -2 };
         BOOST_CHECK_EQUAL(std::format("{}", d), "(1, -2)");
         BOOST_CHECK_EQUAL(std::format(L"{}", d), std::wstring(L"(1, -2)"));
+}
+
+BOOST_AUTO_TEST_CASE(StreamInsertion)
+{
+        xstd::div_t const d { 1, -2 };
+
+        std::ostringstream oss;
+        oss << d;
+        BOOST_CHECK_EQUAL(oss.str(), "(1, -2)");
+        BOOST_CHECK_EQUAL(oss.str(), std::format("{}", d));
+
+        std::wostringstream woss;
+        woss << d;
+        BOOST_CHECK(woss.str() == L"(1, -2)");
+        BOOST_CHECK(woss.str() == std::format(L"{}", d));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -4,7 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <xstd/cstdlib.hpp>             // div, floored_div, euclidean_div
-#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_CHECK_EQUAL, BOOST_CHECK_EQUAL_COLLECTIONS
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_EQUAL_COLLECTIONS, BOOST_CHECK_MESSAGE
 #include <algorithm>                    // transform
 #include <array>                        // array
 #include <cstdlib>                      // div, div_t
@@ -189,6 +189,42 @@ BOOST_AUTO_TEST_CASE(StreamInsertion)
         woss << d;
         BOOST_CHECK(woss.str() == L"(1, -2)");
         BOOST_CHECK(woss.str() == std::format(L"{}", d));
+}
+
+BOOST_AUTO_TEST_CASE(StreamExtraction)
+{
+        std::istringstream iss("(1, -2)");
+        xstd::div_t d{};
+        iss >> d;
+        BOOST_CHECK(!iss.fail());
+        BOOST_CHECK_EQUAL(d, (xstd::div_t{1, -2}));
+
+        // whitespace between the tokens is optional
+        std::istringstream compact("(1,-2)");
+        xstd::div_t c{};
+        compact >> c;
+        BOOST_CHECK(!compact.fail());
+        BOOST_CHECK_EQUAL(c, (xstd::div_t{1, -2}));
+
+        // insertion and extraction round-trip
+        auto const original = xstd::div_t{-3, +1};
+        std::stringstream ss;
+        ss << original;
+        xstd::div_t roundtripped{};
+        ss >> roundtripped;
+        BOOST_CHECK(!ss.fail());
+        BOOST_CHECK_EQUAL(roundtripped, original);
+}
+
+BOOST_AUTO_TEST_CASE(StreamExtractionFailure)
+{
+        for (auto const malformed : { "", "garbage", "1, -2)", "(x, -2)", "(1; -2)", "(1, x)", "(1, -2(" }) {
+                std::istringstream iss(malformed);
+                auto d = xstd::div_t{+7, -9};
+                iss >> d;
+                BOOST_CHECK_MESSAGE(iss.fail(), std::format("'{}' must set failbit", malformed));
+                BOOST_CHECK_EQUAL(d, (xstd::div_t{+7, -9}));    // d is left unmodified
+        }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -26,6 +26,25 @@ static_assert(xstd::floored_div(-8, +3) == xstd::div_t{-3, +1});
 
 BOOST_AUTO_TEST_SUITE(CStdLib)
 
+template<class T>
+concept has_abs = requires(T x) { xstd::abs(x); };
+
+template<class T>
+concept has_sign = requires(T x) { xstd::sign(x); };
+
+// abs and sign accept arithmetic types except bool, and reject anything else
+static_assert( has_abs<int>  &&  has_sign<int>);
+static_assert( has_abs<char> &&  has_sign<char>);
+static_assert( has_abs<double> && has_sign<double>);
+static_assert( has_abs<unsigned> && has_sign<unsigned>);
+static_assert(!has_abs<bool> && !has_sign<bool>);
+static_assert(!has_abs<void*> && !has_sign<void*>);
+
+// as with the built-in unary minus, the result is promoted for integral
+// types narrower than int, which makes abs of their lowest values well-defined
+static_assert(std::is_same_v<decltype(xstd::abs(short())), int>);
+static_assert(xstd::abs(std::numeric_limits<short>::min()) == -(std::numeric_limits<short>::min() + 1) + 1);
+
 BOOST_AUTO_TEST_CASE(Abs)
 {
         BOOST_CHECK_EQUAL(xstd::abs(-2), 2);
@@ -33,6 +52,14 @@ BOOST_AUTO_TEST_CASE(Abs)
         BOOST_CHECK_EQUAL(xstd::abs( 0), 0);
         BOOST_CHECK_EQUAL(xstd::abs(+1), 1);
         BOOST_CHECK_EQUAL(xstd::abs(+2), 2);
+
+        BOOST_CHECK_EQUAL(xstd::abs(-2.5), 2.5);
+        BOOST_CHECK_EQUAL(xstd::abs(+2.5), 2.5);
+        BOOST_CHECK_EQUAL(xstd::abs(7u), 7u);           // the identity for unsigned types
+
+        using limits = std::numeric_limits<int>;
+        BOOST_CHECK_EQUAL(xstd::abs(limits::max()), limits::max());
+        BOOST_CHECK_EQUAL(xstd::abs(limits::min() + 1), limits::max());
 }
 
 BOOST_AUTO_TEST_CASE(Sign)
@@ -42,6 +69,11 @@ BOOST_AUTO_TEST_CASE(Sign)
         BOOST_CHECK_EQUAL(xstd::sign( 0),  0);
         BOOST_CHECK_EQUAL(xstd::sign(+1), +1);
         BOOST_CHECK_EQUAL(xstd::sign(+2), +1);
+
+        BOOST_CHECK_EQUAL(xstd::sign(-2.5), -1);
+        BOOST_CHECK_EQUAL(xstd::sign(+0.0),  0);
+        BOOST_CHECK_EQUAL(xstd::sign(-0.0),  0);
+        BOOST_CHECK_EQUAL(xstd::sign(3u),   +1);
 }
 
 // http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -6,7 +6,7 @@
 #include <xstd/type_traits.hpp>         // is_specialization_of, is_integral_constant, tagged_empty, optional_type
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_CHECK
 #include <complex>                      // complex
-#include <type_traits>                  // integral_constant, is_constructible_v, is_convertible_v, is_empty_v, is_same_v
+#include <type_traits>                  // integral_constant, is_constructible_v, is_convertible_v, is_empty_v, is_same_v, is_trivially_constructible_v, is_trivially_copyable_v
 
 using namespace xstd;
 
@@ -51,6 +51,13 @@ BOOST_AUTO_TEST_CASE(TaggedEmpty)
         // constructible from anything, but only explicitly
         static_assert( std::is_constructible_v<empty1, int, double>);
         static_assert(!std::is_convertible_v<int, empty1>);
+
+        // the catch-all constructor never hijacks copy/move construction,
+        // not even from a non-const lvalue
+        static_assert(std::is_trivially_copyable_v<empty1>);
+        static_assert(std::is_trivially_constructible_v<empty1, empty1&>);
+        static_assert(std::is_trivially_constructible_v<empty1, empty1 const&>);
+        static_assert(std::is_trivially_constructible_v<empty1, empty1&&>);
 
         // stateless: all instances compare equal, regardless of construction
         static_assert(empty1(1, 2.0) == empty1());

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,15 @@
   "description": "Extensions to the C++ Standard Library",
   "homepage": "https://github.com/rhalbersma/xstd",
   "license": "BSL-1.0",
-  "dependencies": [
-    "boost-test"
-  ]
+  "default-features": [
+    "test"
+  ],
+  "features": {
+    "test": {
+      "description": "Build the Boost.Test-based unit tests",
+      "dependencies": [
+        "boost-test"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
This PR enhances the `div_t` type with improved stream insertion/extraction operators and significantly expands test coverage for the `cstdlib` module. It also includes infrastructure improvements for CI/CD and build configuration.

## Key Changes

### Core Library Changes (`include/xstd/cstdlib.hpp`)
- **Refactored stream operators**: Moved `operator<<` and `operator>>` implementations to after the `std::formatter` specialization, allowing them to delegate to `std::format` for consistency
- **Improved `operator>>`**: Enhanced to properly handle malformed input by setting `failbit` and leaving the target unmodified, following standard library conventions
- **Added constraints to `abs` and `sign`**: Explicitly reject `bool` type (in addition to non-arithmetic types) to prevent misuse
- **Added assertions**: `abs()` now asserts that signed integral types don't have their minimum value (which would overflow)

### Test Enhancements (`test/src/cstdlib.cpp`)
- **Added compile-time concept tests**: Verify that `abs` and `sign` accept arithmetic types (except `bool`) and reject pointers
- **Expanded `abs` test cases**: Added tests for floating-point and unsigned types, plus edge cases with `numeric_limits`
- **Expanded `sign` test cases**: Added tests for floating-point, unsigned types, and negative zero
- **New `StreamInsertion` test**: Verifies that `operator<<` produces output matching `std::format`
- **New `StreamExtraction` test**: Tests successful parsing of well-formed input and round-trip serialization
- **New `StreamExtractionFailure` test**: Validates that malformed input properly sets `failbit` and leaves the value unmodified

### Build & CI/CD Infrastructure
- **CMake improvements**: 
  - Reorganized test configuration to apply warning flags to header self-sufficiency tests
  - Added support for vcpkg-based builds with CMakePresets
  - Conditional test building only when xstd is the top-level project
  - Modernized path operations (`cmake_path` instead of `get_filename_component`)
- **New Clang-Tidy workflow**: Added static analysis over public headers with configurable checks
- **Enhanced existing workflows**: Added permissions, concurrency controls, and libc++ support for Clang
- **Coverage improvements**: Added line coverage enforcement (100% for `include/`), Codecov integration, and summary reporting
- **vcpkg configuration**: Added feature-based test dependency and libc++ triplet/toolchain for alternative standard library testing
- **Dependabot configuration**: Added for automated GitHub Actions updates

### Type Traits Improvements (`include/xstd/type_traits.hpp`)
- **Constrained `tagged_empty` constructor**: Added template constraint to prevent hijacking of copy/move construction from special member functions

### Documentation
- Updated README with Codecov badge and clarified that tests only build when xstd is the top-level project

## Notable Implementation Details
- Stream operators now use `.c_str()` to work with any `Traits` template parameter
- Stream extraction uses a lambda helper to validate expected tokens and set `failbit` on mismatch
- The `abs()` function properly handles integral type promotion for types narrower than `int`, making `abs(short::min())` well-defined

https://claude.ai/code/session_01HQ6P5nZPtN3NKAmojgX4Gw