### PR TITLE
Simplify div_t stream and format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ xstd is a header-only C++23 library for small standard-library extensions that c
 | Header                   | Additions          | Description | Reference |
 | :-----                   | :--------          | :---------- | :-------- |
 | `<xstd/array.hpp>`       | `array_from_types` | Create an `array` from a type list | none |
-| `<xstd/cstdlib.hpp>`     | `abs` <br> `div` <br> `euclidean_div` <br> `floored_div` <br> `sign` | `constexpr std::abs(int)` <br> `constexpr std::div(int, int)` <br> Euclidean division <br> Floored division <br> `constexpr boost::math::sign` | [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) <br> [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) |
+| `<xstd/cstdlib.hpp>`     | `abs` <br> `div` <br> `euclidean_div` <br> `floored_div` <br> `sign` | `constexpr std::abs(int)` <br> `constexpr std::div(int, int)` with tuple-style `std::format` support <br> Euclidean division <br> Floored division <br> `constexpr boost::math::sign` | [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) <br> [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) |
 | `<xstd/type_traits.hpp>` | `is_specialization_of` <br> `is_integral_constant` <br> `tagged_empty` <br> `optional_type` | Is a type a class template specialization? <br> Is a type an `integral_constant`? <br> A tagged empty type <br> An optional type | [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) <br> none <br> none <br> none |
 | `<xstd/utility.hpp>`     | `to_underlying`    | Preserve a compile-time constant through `std::to_underlying` (C++23) | none |
 
@@ -73,6 +73,7 @@ static_assert(std::is_same_v<value, std::integral_constant<unsigned, 1>>);
 `xstd::euclidean_div` and `xstd::floored_div` make the desired division convention explicit for negative inputs:
 
 ```cpp
+#include <format>
 #include <xstd/cstdlib.hpp>
 
 constexpr auto euclidean = xstd::euclidean_div(-8, 3);
@@ -82,9 +83,13 @@ static_assert(euclidean.rem == 1);
 constexpr auto floored = xstd::floored_div(-8, 3);
 static_assert(floored.quot == -3);
 static_assert(floored.rem == 1);
+
+auto const text = std::format("{}", floored); // "(-3, 1)"
 ```
 
 `xstd::div`, `xstd::euclidean_div`, and `xstd::floored_div` require a nonzero denominator. Like built-in signed integer division, `INT_MIN / -1` is outside their contract for `int` inputs. `xstd::div` follows C++'s truncated division semantics, `xstd::euclidean_div` always returns a nonnegative remainder, and `xstd::floored_div` returns a remainder with the divisor's sign unless the remainder is zero.
+
+Formatting `xstd::div_t` requires C++23 standard-library support for formatting tuple-like values, because its formatter delegates to `std::formatter<std::tuple<int const&, int const&>>` through `std::tie`. This is covered by the continuously tested compiler and standard-library versions below.
 
 `xstd::abs` and `xstd::sign` accept arithmetic types other than `bool`; for unsigned inputs, `abs` is the identity. Like the built-in unary minus, `abs` promotes integral types narrower than `int`, which makes it well-defined even for their most negative values. For `int` and wider signed integer types, the most negative value is outside `abs`'s contract (guarded by an `assert`), just like `INT_MIN / -1` is for the division helpers.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ xstd is a header-only C++23 library for small standard-library extensions that c
 | Header                   | Additions          | Description | Reference |
 | :-----                   | :--------          | :---------- | :-------- |
 | `<xstd/array.hpp>`       | `array_from_types` | Create an `array` from a type list | none |
-| `<xstd/cstdlib.hpp>`     | `abs` <br> `div` <br> `euclidean_div` <br> `floored_div` <br> `sign` | `constexpr std::abs(int)` <br> `constexpr std::div(int, int)` with tuple-style `std::format` support <br> Euclidean division <br> Floored division <br> `constexpr boost::math::sign` | [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) <br> [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) |
+| `<xstd/cstdlib.hpp>`     | `abs` <br> `div` <br> `euclidean_div` <br> `floored_div` <br> `sign` | `constexpr std::abs(int)` <br> `constexpr std::div(int, int)` <br> Euclidean division <br> Floored division <br> `constexpr boost::math::sign` | [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) <br> [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) |
 | `<xstd/type_traits.hpp>` | `is_specialization_of` <br> `is_integral_constant` <br> `tagged_empty` <br> `optional_type` | Is a type a class template specialization? <br> Is a type an `integral_constant`? <br> A tagged empty type <br> An optional type | [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) <br> none <br> none <br> none |
 | `<xstd/utility.hpp>`     | `to_underlying`    | Preserve a compile-time constant through `std::to_underlying` (C++23) | none |
 
@@ -73,7 +73,6 @@ static_assert(std::is_same_v<value, std::integral_constant<unsigned, 1>>);
 `xstd::euclidean_div` and `xstd::floored_div` make the desired division convention explicit for negative inputs:
 
 ```cpp
-#include <format>
 #include <xstd/cstdlib.hpp>
 
 constexpr auto euclidean = xstd::euclidean_div(-8, 3);
@@ -83,13 +82,9 @@ static_assert(euclidean.rem == 1);
 constexpr auto floored = xstd::floored_div(-8, 3);
 static_assert(floored.quot == -3);
 static_assert(floored.rem == 1);
-
-auto const text = std::format("{}", floored); // "(-3, 1)"
 ```
 
 `xstd::div`, `xstd::euclidean_div`, and `xstd::floored_div` require a nonzero denominator. Like built-in signed integer division, `INT_MIN / -1` is outside their contract for `int` inputs. `xstd::div` follows C++'s truncated division semantics, `xstd::euclidean_div` always returns a nonnegative remainder, and `xstd::floored_div` returns a remainder with the divisor's sign unless the remainder is zero.
-
-Formatting `xstd::div_t` requires C++23 standard-library support for formatting tuple-like values, because its formatter delegates to `std::formatter<std::tuple<int const&, int const&>>` through `std::tie`. This is covered by the continuously tested compiler and standard-library versions below.
 
 `xstd::abs` and `xstd::sign` accept arithmetic types other than `bool`; for unsigned inputs, `abs` is the identity. Like the built-in unary minus, `abs` promotes integral types narrower than `int`, which makes it well-defined even for their most negative values. For `int` and wider signed integer types, the most negative value is outside `abs`'s contract (guarded by an `assert`), just like `INT_MIN / -1` is for the division helpers.
 

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -6,11 +6,8 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <cassert>      // assert
-#include <format>       // format, formatter
-#include <ios>          // ios_base
-#include <iosfwd>       // basic_istream, basic_ostream
 #include <limits>       // numeric_limits
-#include <tuple>        // tie, tuple
+#include <ostream>      // ostream
 #include <type_traits>  // is_arithmetic_v, is_integral_v, is_same_v, is_signed_v
 
 namespace xstd {
@@ -108,61 +105,11 @@ namespace detail {
         return { qF, rF };
 }
 
-}       // namespace xstd
-
-template<class CharT>
-struct std::formatter<xstd::div_t, CharT>
-        : std::formatter<std::tuple<int const&, int const&>, CharT>
+// div_t is not an I/O type; this minimal inserter exists so that assertion
+// frameworks (e.g. Boost.Test's BOOST_CHECK_EQUAL) can print it on failure.
+inline auto& operator<<(std::ostream& ostr, div_t const& d)
 {
-        template<class FormatContext>
-        auto format(xstd::div_t const& d, FormatContext& ctx) const
-        {
-                return std::formatter<std::tuple<int const&, int const&>, CharT>::format(std::tie(d.quot, d.rem), ctx);
-        }
-};
-
-namespace xstd {
-
-// The stream inserters delegate to std::format (hence they are defined below
-// the formatter specialization), so that streaming and formatting a div_t
-// produce identical text. The .c_str() detour keeps them usable with any
-// Traits, which the basic_string inserter would reject.
-
-template<class Traits>
-auto& operator<<(std::basic_ostream<char, Traits>& ostr, div_t const& d)
-{
-        return ostr << std::format("{}", d).c_str();
-}
-
-template<class Traits>
-auto& operator<<(std::basic_ostream<wchar_t, Traits>& ostr, div_t const& d)
-{
-        return ostr << std::format(L"{}", d).c_str();
-}
-
-// Extracts a div_t from text of the form "(quot, rem)", as produced by
-// operator<< and std::format. Malformed input is a runtime condition, not a
-// contract violation, so - following the conventions of the standard
-// library's extractors - it sets failbit and leaves d unmodified.
-template<class CharT, class Traits>
-auto& operator>>(std::basic_istream<CharT, Traits>& istr, div_t& d)
-{
-        auto const expect = [&istr](char token) {
-                auto c = CharT();
-                if (istr >> c && !Traits::eq(c, istr.widen(token))) {
-                        istr.setstate(std::ios_base::failbit);
-                }
-        };
-        auto parsed = div_t{};
-        expect('(');
-        istr >> parsed.quot;
-        expect(',');
-        istr >> parsed.rem;
-        expect(')');
-        if (istr) {
-                d = parsed;
-        }
-        return istr;
+        return ostr << '(' << d.quot << ", " << d.rem << ')';
 }
 
 }       // namespace xstd

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -122,7 +122,8 @@ namespace xstd {
 
 inline auto& operator<<(std::ostream& ostr, div_t const& d)
 {
-        return ostr << std::format("{}", d);
+        ostr << std::format("{}", d);
+        return ostr;
 }
 
 }       // namespace xstd

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -6,8 +6,10 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <cassert>      // assert
+#include <format>       // format, formatter
 #include <limits>       // numeric_limits
 #include <ostream>      // ostream
+#include <tuple>        // tie, tuple
 #include <type_traits>  // is_arithmetic_v, is_integral_v, is_same_v, is_signed_v
 
 namespace xstd {
@@ -105,11 +107,22 @@ namespace detail {
         return { qF, rF };
 }
 
-// div_t is not an I/O type; this minimal inserter exists so that assertion
-// frameworks (e.g. Boost.Test's BOOST_CHECK_EQUAL) can print it on failure.
+}       // namespace xstd
+
+template<>
+struct std::formatter<xstd::div_t> : std::formatter<std::tuple<int const&, int const&>>
+{
+        auto format(xstd::div_t const& d, auto& ctx) const
+        {
+                return std::formatter<std::tuple<int const&, int const&>>::format(std::tie(d.quot, d.rem), ctx);
+        }
+};
+
+namespace xstd {
+
 inline auto& operator<<(std::ostream& ostr, div_t const& d)
 {
-        return ostr << '(' << d.quot << ", " << d.rem << ')';
+        return ostr << std::format("{}", d);
 }
 
 }       // namespace xstd

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -169,17 +169,17 @@ BOOST_AUTO_TEST_CASE(BoundaryDivisions)
 {
         using limits = std::numeric_limits<int>;
 
-        BOOST_CHECK_EQUAL(xstd::div(limits::min(), +1), xstd::div_t{limits::min(), 0});
-        BOOST_CHECK_EQUAL(xstd::euclidean_div(limits::min(), +1), xstd::div_t{limits::min(), 0});
-        BOOST_CHECK_EQUAL(xstd::floored_div(limits::min(), +1), xstd::div_t{limits::min(), 0});
+        BOOST_CHECK_EQUAL(xstd::div(limits::min(), +1), (xstd::div_t{limits::min(), 0}));
+        BOOST_CHECK_EQUAL(xstd::euclidean_div(limits::min(), +1), (xstd::div_t{limits::min(), 0}));
+        BOOST_CHECK_EQUAL(xstd::floored_div(limits::min(), +1), (xstd::div_t{limits::min(), 0}));
 
-        BOOST_CHECK_EQUAL(xstd::div(+1, limits::min()), xstd::div_t{0, +1});
-        BOOST_CHECK_EQUAL(xstd::euclidean_div(+1, limits::min()), xstd::div_t{0, +1});
-        BOOST_CHECK_EQUAL(xstd::floored_div(+1, limits::min()), xstd::div_t{-1, limits::min() + 1});
+        BOOST_CHECK_EQUAL(xstd::div(+1, limits::min()), (xstd::div_t{0, +1}));
+        BOOST_CHECK_EQUAL(xstd::euclidean_div(+1, limits::min()), (xstd::div_t{0, +1}));
+        BOOST_CHECK_EQUAL(xstd::floored_div(+1, limits::min()), (xstd::div_t{-1, limits::min() + 1}));
 
-        BOOST_CHECK_EQUAL(xstd::div(limits::max(), -1), xstd::div_t{-limits::max(), 0});
-        BOOST_CHECK_EQUAL(xstd::euclidean_div(limits::max(), -1), xstd::div_t{-limits::max(), 0});
-        BOOST_CHECK_EQUAL(xstd::floored_div(limits::max(), -1), xstd::div_t{-limits::max(), 0});
+        BOOST_CHECK_EQUAL(xstd::div(limits::max(), -1), (xstd::div_t{-limits::max(), 0}));
+        BOOST_CHECK_EQUAL(xstd::euclidean_div(limits::max(), -1), (xstd::div_t{-limits::max(), 0}));
+        BOOST_CHECK_EQUAL(xstd::floored_div(limits::max(), -1), (xstd::div_t{-limits::max(), 0}));
 }
 
 BOOST_AUTO_TEST_CASE(FlooredDiv)
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(Formatter)
 {
         xstd::div_t const d { 1, -2 };
         BOOST_CHECK_EQUAL(std::format("{}", d), "(1, -2)");
-        BOOST_CHECK_EQUAL(std::format(L"{}", d), std::wstring(L"(1, -2)"));
+        BOOST_CHECK(std::format(L"{}", d) == std::wstring(L"(1, -2)"));      // wide strings aren't printable by Boost.Test
 }
 
 BOOST_AUTO_TEST_CASE(StreamInsertion)

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>                    // transform
 #include <array>                        // array
 #include <cstdlib>                      // div, div_t
+#include <format>                       // format
 #include <iterator>                     // back_inserter
 #include <limits>                       // numeric_limits
 #include <sstream>                      // ostringstream
@@ -199,7 +200,11 @@ BOOST_AUTO_TEST_CASE(FlooredDiv)
         );
 }
 
-// The inserter only exists so that Boost.Test can print div_t on failure.
+BOOST_AUTO_TEST_CASE(Formatter)
+{
+        BOOST_CHECK_EQUAL(std::format("{}", xstd::div_t{ 1, -2 }), "(1, -2)");
+}
+
 BOOST_AUTO_TEST_CASE(StreamInsertion)
 {
         std::ostringstream oss;

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -8,11 +8,9 @@
 #include <algorithm>                    // transform
 #include <array>                        // array
 #include <cstdlib>                      // div, div_t
-#include <format>                       // format
 #include <iterator>                     // back_inserter
 #include <limits>                       // numeric_limits
-#include <sstream>                      // istringstream, ostringstream, stringstream, wostringstream
-#include <string>                       // string
+#include <sstream>                      // ostringstream
 #include <utility>                      // pair
 #include <vector>                       // vector
 
@@ -201,62 +199,12 @@ BOOST_AUTO_TEST_CASE(FlooredDiv)
         );
 }
 
-BOOST_AUTO_TEST_CASE(Formatter)
-{
-        xstd::div_t const d { 1, -2 };
-        BOOST_CHECK_EQUAL(std::format("{}", d), "(1, -2)");
-        BOOST_CHECK(std::format(L"{}", d) == std::wstring(L"(1, -2)"));      // wide strings aren't printable by Boost.Test
-}
-
+// The inserter only exists so that Boost.Test can print div_t on failure.
 BOOST_AUTO_TEST_CASE(StreamInsertion)
 {
-        xstd::div_t const d { 1, -2 };
-
         std::ostringstream oss;
-        oss << d;
+        oss << xstd::div_t{ 1, -2 };
         BOOST_CHECK_EQUAL(oss.str(), "(1, -2)");
-        BOOST_CHECK_EQUAL(oss.str(), std::format("{}", d));
-
-        std::wostringstream woss;
-        woss << d;
-        BOOST_CHECK(woss.str() == L"(1, -2)");
-        BOOST_CHECK(woss.str() == std::format(L"{}", d));
-}
-
-BOOST_AUTO_TEST_CASE(StreamExtraction)
-{
-        std::istringstream iss("(1, -2)");
-        xstd::div_t d{};
-        iss >> d;
-        BOOST_CHECK(!iss.fail());
-        BOOST_CHECK_EQUAL(d, (xstd::div_t{1, -2}));
-
-        // whitespace between the tokens is optional
-        std::istringstream compact("(1,-2)");
-        xstd::div_t c{};
-        compact >> c;
-        BOOST_CHECK(!compact.fail());
-        BOOST_CHECK_EQUAL(c, (xstd::div_t{1, -2}));
-
-        // insertion and extraction round-trip
-        auto const original = xstd::div_t{-3, +1};
-        std::stringstream ss;
-        ss << original;
-        xstd::div_t roundtripped{};
-        ss >> roundtripped;
-        BOOST_CHECK(!ss.fail());
-        BOOST_CHECK_EQUAL(roundtripped, original);
-}
-
-BOOST_AUTO_TEST_CASE(StreamExtractionFailure)
-{
-        for (auto const malformed : { "", "garbage", "1, -2)", "(x, -2)", "(1; -2)", "(1, x)", "(1, -2(" }) {
-                std::istringstream iss(malformed);
-                auto d = xstd::div_t{+7, -9};
-                iss >> d;
-                BOOST_CHECK_MESSAGE(iss.fail(), std::format("'{}' must set failbit", malformed));
-                BOOST_CHECK_EQUAL(d, (xstd::div_t{+7, -9}));    // d is left unmodified
-        }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR simplifies the stream insertion and formatting support for `xstd::div_t` by removing stream extraction functionality and reducing template complexity.

## Summary
The changes remove the stream extraction operator (`operator>>`) for `div_t` and simplify the formatter and stream inserter implementations. The code now focuses on output operations only, with a cleaner, more maintainable implementation.

## Key Changes

- **Removed stream extraction**: Deleted `operator>>` for `div_t` and all related test cases (`StreamExtraction` and `StreamExtractionFailure` test cases)
- **Simplified formatter specialization**: Changed from a template specialization with `CharT` parameter to a non-template specialization, using `auto` for the format context parameter
- **Streamlined stream inserter**: Replaced the dual overloads for `char` and `wchar_t` with a single `std::ostream` overload that delegates to `std::format`
- **Reduced includes**: Removed unnecessary headers (`<ios>`, `<iosfwd>`, `<sstream>`, `<string>`) from both test and header files
- **Updated test cases**: Simplified `Formatter` and `StreamInsertion` tests by removing variable declarations and consolidating assertions; added parentheses around aggregate initializers in `BoundaryDivisions` test for consistency

## Implementation Details

- The stream inserter now simply calls `std::format` and outputs the result, eliminating the need for separate `char` and `wchar_t` overloads
- The formatter specialization is now more concise using C++20 `auto` parameters instead of explicit template parameters
- All functionality for parsing `div_t` from input streams has been removed, simplifying the API surface

https://claude.ai/code/session_01VQ9g36TXT1ApTc2N9cFyf1