### PR TITLE
Replace static_assert with XSTD_CONSTEXPR_CHECK in tests

### DIFF
--- a/test/include/xstd/test/constexpr.hpp
+++ b/test/include/xstd/test/constexpr.hpp
@@ -3,8 +3,8 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef XSTD_TEST_CONSTEXPR_CHECK_HPP
-#define XSTD_TEST_CONSTEXPR_CHECK_HPP
+#ifndef XSTD_TEST_CONSTEXPR_HPP
+#define XSTD_TEST_CONSTEXPR_HPP
 
 #include <boost/test/unit_test.hpp>     // BOOST_CHECK, BOOST_CHECK_EQUAL
 
@@ -23,4 +23,4 @@
         static_assert((a) == (b)); \
         BOOST_CHECK_EQUAL((a), (b))
 
-#endif  // XSTD_TEST_CONSTEXPR_CHECK_HPP
+#endif  // XSTD_TEST_CONSTEXPR_HPP

--- a/test/src/array.cpp
+++ b/test/src/array.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(ArrayFromTypes)
                 return sizeof(T);
         });
 
-        static_assert(std::is_same_v<decltype(sizes), std::array<std::size_t, 3> const>);
+        XSTD_CONSTEXPR_CHECK((std::is_same_v<decltype(sizes), std::array<std::size_t, 3> const>));
 
         XSTD_CONSTEXPR_CHECK_EQUAL(sizes[0], sizeof(int));
         XSTD_CONSTEXPR_CHECK_EQUAL(sizes[1], sizeof(double));
@@ -52,8 +52,7 @@ BOOST_AUTO_TEST_CASE(WorksWithNonDefaultConstructibleTypes)
         constexpr auto sizes = array_from_types<type_list<non_default_constructible>>()([]<class T>(std::type_identity<T>) {
                 return sizeof(T);
         });
-        static_assert(sizes == std::array{sizeof(non_default_constructible)});
-        XSTD_CONSTEXPR_CHECK_EQUAL(sizes[0], sizeof(non_default_constructible));
+        XSTD_CONSTEXPR_CHECK(sizes == std::array{sizeof(non_default_constructible)});
 }
 
 BOOST_AUTO_TEST_CASE(RequiresNonEmptyTypeList)
@@ -61,7 +60,7 @@ BOOST_AUTO_TEST_CASE(RequiresNonEmptyTypeList)
         // an empty type list leaves no type for std::array's CTAD to deduce,
         // so the call operator's constraint rejects it up front
         auto const fun = [](auto) { return 1; };
-        static_assert(std::is_invocable_v<array_from_types<type_list<int>>, decltype(fun)>);
+        XSTD_CONSTEXPR_CHECK((std::is_invocable_v<array_from_types<type_list<int>>, decltype(fun)>));
         XSTD_CONSTEXPR_CHECK((!std::is_invocable_v<array_from_types<type_list<>>, decltype(fun)>));
 }
 

--- a/test/src/array.cpp
+++ b/test/src/array.cpp
@@ -4,7 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <xstd/array.hpp>               // array_from_types
-#include <xstd/test/constexpr_check.hpp> // XSTD_CONSTEXPR_CHECK, XSTD_CONSTEXPR_CHECK_EQUAL
+#include <xstd/test/constexpr.hpp>      // XSTD_CONSTEXPR_CHECK, XSTD_CONSTEXPR_CHECK_EQUAL
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
 #include <array>                        // array
 #include <cstddef>                      // size_t

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -4,7 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <xstd/cstdlib.hpp>             // div, floored_div, euclidean_div
-#include <xstd/test/constexpr_check.hpp> // XSTD_CONSTEXPR_CHECK_EQUAL
+#include <xstd/test/constexpr.hpp>      // XSTD_CONSTEXPR_CHECK_EQUAL
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_CHECK_EQUAL, BOOST_CHECK_EQUAL_COLLECTIONS
 #include <algorithm>                    // transform
 #include <array>                        // array

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -46,19 +46,19 @@ BOOST_AUTO_TEST_CASE(TaggedEmpty)
         using empty1 = tagged_empty<tag1>;
         using empty2 = tagged_empty<tag2>;
 
-        static_assert( std::is_empty_v<empty1>);
-        static_assert(!std::is_same_v<empty1, empty2>);
+        XSTD_CONSTEXPR_CHECK(( std::is_empty_v<empty1>));
+        XSTD_CONSTEXPR_CHECK((!std::is_same_v<empty1, empty2>));
 
         // constructible from anything, but only explicitly
-        static_assert( std::is_constructible_v<empty1, int, double>);
-        static_assert(!std::is_convertible_v<int, empty1>);
+        XSTD_CONSTEXPR_CHECK(( std::is_constructible_v<empty1, int, double>));
+        XSTD_CONSTEXPR_CHECK((!std::is_convertible_v<int, empty1>));
 
         // the catch-all constructor never hijacks copy/move construction,
         // not even from a non-const lvalue
-        static_assert(std::is_trivially_copyable_v<empty1>);
-        static_assert(std::is_trivially_constructible_v<empty1, empty1&>);
-        static_assert(std::is_trivially_constructible_v<empty1, empty1 const&>);
-        static_assert(std::is_trivially_constructible_v<empty1, empty1&&>);
+        XSTD_CONSTEXPR_CHECK(std::is_trivially_copyable_v<empty1>);
+        XSTD_CONSTEXPR_CHECK((std::is_trivially_constructible_v<empty1, empty1&>));
+        XSTD_CONSTEXPR_CHECK((std::is_trivially_constructible_v<empty1, empty1 const&>));
+        XSTD_CONSTEXPR_CHECK((std::is_trivially_constructible_v<empty1, empty1&&>));
 
         // stateless: all instances compare equal, regardless of construction
         XSTD_CONSTEXPR_CHECK(empty1(1, 2.0) == empty1());
@@ -68,8 +68,8 @@ BOOST_AUTO_TEST_CASE(TaggedEmpty)
 BOOST_AUTO_TEST_CASE(OptionalType)
 {
         XSTD_CONSTEXPR_CHECK((std::is_same_v<optional_type<true,  tag1>, tag1>));
-        static_assert(std::is_same_v<optional_type<false, tag1>, tagged_empty<tag1>>);
-        static_assert(std::is_empty_v<optional_type<false, tag1>>);
+        XSTD_CONSTEXPR_CHECK((std::is_same_v<optional_type<false, tag1>, tagged_empty<tag1>>));
+        XSTD_CONSTEXPR_CHECK(std::is_empty_v<optional_type<false, tag1>>);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(OptionalType)
 {
         XSTD_CONSTEXPR_CHECK((std::is_same_v<optional_type<true,  tag1>, tag1>));
         XSTD_CONSTEXPR_CHECK((std::is_same_v<optional_type<false, tag1>, tagged_empty<tag1>>));
-        XSTD_CONSTEXPR_CHECK(std::is_empty_v<optional_type<false, tag1>>);
+        XSTD_CONSTEXPR_CHECK((std::is_empty_v<optional_type<false, tag1>>));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -4,7 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <xstd/type_traits.hpp>         // is_specialization_of, is_integral_constant, tagged_empty, optional_type
-#include <xstd/test/constexpr_check.hpp> // XSTD_CONSTEXPR_CHECK
+#include <xstd/test/constexpr.hpp>      // XSTD_CONSTEXPR_CHECK
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
 #include <complex>                      // complex
 #include <type_traits>                  // integral_constant, is_constructible_v, is_convertible_v, is_empty_v, is_same_v, is_trivially_constructible_v, is_trivially_copyable_v

--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -4,7 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <xstd/utility.hpp>             // to_underlying
-#include <xstd/test/constexpr_check.hpp> // XSTD_CONSTEXPR_CHECK_EQUAL
+#include <xstd/test/constexpr.hpp>      // XSTD_CONSTEXPR_CHECK_EQUAL
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
 #include <type_traits>                  // integral_constant
 #include <utility>                      // to_underlying


### PR DESCRIPTION
This PR converts compile-time assertions in the test suite from `static_assert` to `XSTD_CONSTEXPR_CHECK` for consistency and improved test infrastructure integration.

## Summary
Updated type trait tests to use the `XSTD_CONSTEXPR_CHECK` macro instead of `static_assert` statements. This change allows these compile-time checks to be integrated with the test framework's reporting and execution model.

## Key Changes
- **type_traits.cpp**: Converted 10 `static_assert` statements to `XSTD_CONSTEXPR_CHECK` in the `TaggedEmpty` and `OptionalType` test cases
- **array.cpp**: Converted 3 `static_assert` statements to `XSTD_CONSTEXPR_CHECK` in array-related test cases
- Added parentheses around boolean expressions where needed for macro compatibility
- Removed a redundant `XSTD_CONSTEXPR_CHECK_EQUAL` call in `WorksWithNonDefaultConstructibleTypes` test

## Notable Details
- All assertions remain functionally equivalent; only the assertion mechanism changed
- The macro wrapping ensures proper parenthesization of complex type trait expressions
- This standardizes the test assertion style across the test suite

https://claude.ai/code/session_0132pYrjYW2aM2ofnjPGymrG