### PR TITLE
Add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Clang-CL](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml)
 [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml)
 [![Coverage](https://codecov.io/gh/rhalbersma/xstd/branch/master/graph/badge.svg)](https://codecov.io/gh/rhalbersma/xstd)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/rhalbersma/xstd/badge)](https://securityscorecards.dev/viewer/?uri=github.com/rhalbersma/xstd)
 
 xstd is a header-only C++23 library for small standard-library extensions that can be implemented portably with stable compiler technology. It aims to prototype future-stdlib-style facilities without requiring experimental language features. See [doc/design.md](doc/design.md) for the design philosophy tying the headers together.
 


### PR DESCRIPTION
## Summary
- Add an [OpenSSF Scorecard](https://securityscorecards.dev) badge to the README, next to the Coverage badge

## Why
Surfaces the automated OSS soundness score (build hardening, branch protection, SAST, pinned dependencies, etc.) that securityscorecards.dev already computes for any public GitHub repo. No extra workflow is required — the badge is served by `api.securityscorecards.dev` and computed on demand.

## Test plan
- [x] Badge markdown follows the same pattern as the existing badges in README.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01CMXRRWhrv52a8rEQHcvtYV)_