### PR TITLE
Add OpenSSF Scorecard workflow to actively publish results

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+name: Scorecard
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ main ]
+  branch_protection_rule:
+  schedule:
+    - cron: '30 4 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@f2ea147fec3c2f0d459703eba7405b5e9bcd8c8f # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Publishing results (above) pushes the score to the public dataset
+      # that api.securityscorecards.dev's README badge reads from. Uploading
+      # to code scanning (below) additionally surfaces the same findings in
+      # this repo's own Security tab.
+      - name: Upload SARIF results as an artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF results to code scanning
+        uses: github/codeql-action/upload-sarif@ddf5ce7296213f5548c91e2dd19df2d77d2b2d66 # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Add `.github/workflows/scorecard.yml`, running `ossf/scorecard-action` on push to `main`, on branch-protection-rule changes, and weekly on a schedule
- `publish_results: true` pushes the score directly to the public dataset that the README's Scorecard badge (`api.securityscorecards.dev`) reads from
- Also uploads the SARIF results to this repo's own Security → Code scanning tab

## Why
The Scorecard badge added in #83 depends on OpenSSF having already scanned the repo, which otherwise only happens on their own crawl schedule (can take up to a day for a newly badged repo). Running the scan ourselves publishes results immediately instead of waiting, and is the officially recommended setup for the badge.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard.yml'))"` — workflow YAML parses
- [ ] CI runs green on this PR
- [ ] Badge renders on `main` after the workflow's first run publishes results


---
_Generated by [Claude Code](https://claude.ai/code/session_01CMXRRWhrv52a8rEQHcvtYV)_