### PR TITLE
Fix ossf/scorecard-action pin: was an imposter (tag-object) SHA

### DIFF
--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -57,7 +57,7 @@ jobs:
           cat > CMakeLists.txt << 'CMAKE'
           cmake_minimum_required(VERSION 3.28)
           project(consumer LANGUAGES CXX)
-          find_package(xstd 0.1 CONFIG REQUIRED)
+          find_package(xstd 0.1.0 CONFIG REQUIRED)
           add_executable(main main.cpp)
           target_link_libraries(main PRIVATE xstd::xstd)
           CMAKE

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -182,7 +182,7 @@ jobs:
           cat > CMakeLists.txt << 'EOF'
           cmake_minimum_required(VERSION 3.28)
           project(consumer LANGUAGES CXX)
-          find_package(xstd 0.1 CONFIG REQUIRED)
+          find_package(xstd 0.1.0 CONFIG REQUIRED)
           add_executable(main main.cpp)
           target_link_libraries(main PRIVATE xstd::xstd)
           EOF

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@f2ea147fec3c2f0d459703eba7405b5e9bcd8c8f # v2.4.3
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ target_link_libraries(my_target PRIVATE xstd::xstd)
 If you've already installed xstd yourself (e.g. `cmake --install`, or your own package manager integration), use `find_package` instead:
 
 ```cmake
-find_package(xstd 0.1 CONFIG REQUIRED)
+find_package(xstd 0.1.0 CONFIG REQUIRED)
 target_link_libraries(my_target PRIVATE xstd::xstd)
 ```
 


### PR DESCRIPTION
## Summary
- Fix the `ossf/scorecard-action` pin in `.github/workflows/scorecard.yml` to use the real commit SHA instead of the annotated tag's object SHA

## Why
`v2.4.3` is an annotated tag, so `git ls-remote --tags` returns the tag *object* SHA rather than the commit it points to. The previous pin (`f2ea147f...`) happened to be a valid commit — but the wrong one (v2.4.2's), off by one row in a `tail` listing. `scorecard-action`'s own publish step performs a stricter self-check than normal Action resolution and rejected it at runtime:

```
error sending scorecard results to webapp: http response 400 ... imposter commit: f2ea147f... does not belong to ossf/scorecard-action
```

This is why merging #84 didn't make the README badge go live — the analysis ran and scored the repo (7.2) but couldn't publish. Using the dereferenced commit SHA (`git ls-remote --tags ... | grep 'v2.4.3\^{}'`) fixes the publish step.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard.yml'))"` — workflow YAML parses
- [ ] CI runs green, and the Scorecard analysis job successfully publishes results this time


---
_Generated by [Claude Code](https://claude.ai/code/session_01CMXRRWhrv52a8rEQHcvtYV)_