### PR TITLE
Fix every remaining tag-object SHA pin across all workflows

### DIFF
--- a/.github/workflows/appleclang.yml
+++ b/.github/workflows/appleclang.yml
@@ -50,7 +50,7 @@ jobs:
       # to the GitHub Actions cache service, so built packages are reused
       # across runs instead of recompiled from scratch every time.
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -57,7 +57,7 @@ jobs:
       # to the GitHub Actions cache service, so built packages are reused
       # across runs instead of recompiled from scratch every time.
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -51,7 +51,7 @@ jobs:
       # to the GitHub Actions cache service, so built packages are reused
       # across runs instead of recompiled from scratch every time.
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -93,7 +93,7 @@ jobs:
       # to the GitHub Actions cache service, so built packages are reused
       # across runs instead of recompiled from scratch every time.
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ddf5ce7296213f5548c91e2dd19df2d77d2b2d66 # v3
+        uses: github/codeql-action/init@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
         with:
           languages: c-cpp
           queries: security-extended
@@ -52,7 +52,7 @@ jobs:
       # to the GitHub Actions cache service, so built packages are reused
       # across runs instead of recompiled from scratch every time.
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -74,6 +74,6 @@ jobs:
         run: cmake --build build -v
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ddf5ce7296213f5548c91e2dd19df2d77d2b2d66 # v3
+        uses: github/codeql-action/analyze@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
         with:
           category: "/language:c-cpp"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,7 @@ jobs:
       # to the GitHub Actions cache service, so built packages are reused
       # across runs instead of recompiled from scratch every time.
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -130,7 +130,7 @@ jobs:
       # percentage below the gcovr-computed one.
       - name: Upload to Codecov
         if: always()
-        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: coverage.xml
           plugins: noop

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -88,7 +88,7 @@ jobs:
       # across runs instead of recompiled from scratch every time.
       - name: Export GitHub Actions cache environment variables
         if: "!matrix.trunk"
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -134,7 +134,7 @@ jobs:
       # across runs instead of recompiled from scratch every time.
       - name: Export GitHub Actions cache environment variables
         if: steps.winlibs.outputs.found == 'true'
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -140,7 +140,7 @@ jobs:
       # to the GitHub Actions cache service, so built packages are reused
       # across runs instead of recompiled from scratch every time.
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -47,7 +47,7 @@ jobs:
       # to the GitHub Actions cache service, so built packages are reused
       # across runs instead of recompiled from scratch every time.
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -54,6 +54,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF results to code scanning
-        uses: github/codeql-action/upload-sarif@ddf5ce7296213f5548c91e2dd19df2d77d2b2d66 # v3
+        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Fix 3 more action pins that were resolved to their annotated tag's *object* SHA instead of the commit it points to: `actions/github-script@v9`, `codecov/codecov-action@v7`, `github/codeql-action@v3` (used in both `codeql.yml` and `scorecard.yml`)

## Why
This is what was actually still blocking the Scorecard badge after #85/#86: `ossf/scorecard-action`'s own pin was fixed, but its workflow-verification step rejects *any* imposter (non-commit) SHA pinned anywhere in the same job — and `scorecard.yml`'s job also calls `github/codeql-action/upload-sarif`, which was still pinned to a tag object. The run after #86 merged failed with the same "imposter commit" error, just for a different action this time.

To avoid a fourth round of this, I audited all 8 third-party action pins in the repo with `git cat-file -t <sha>` against each action's own repo (not just eyeballing `git ls-remote` output) and confirmed each one is genuinely type `commit` before writing it into the workflow.

## Test plan
- [x] `python3 -c "import yaml, glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` — all workflow YAML parses
- [x] All 8 pinned SHAs verified as `commit` objects via `git cat-file -t` against their upstream repos
- [ ] CI runs green, and the Scorecard analysis job successfully publishes results


---
_Generated by [Claude Code](https://claude.ai/code/session_01CMXRRWhrv52a8rEQHcvtYV)_