### PR TITLE
Point CI triggers and consumption example at main, not stale master

### DIFF
--- a/.github/workflows/appleclang.yml
+++ b/.github/workflows/appleclang.yml
@@ -14,9 +14,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -14,9 +14,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -14,9 +14,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -14,9 +14,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -14,9 +14,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -14,9 +14,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,9 +15,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -14,9 +14,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -14,9 +14,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -14,9 +14,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -14,9 +14,9 @@ concurrency:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![AppleClang](https://github.com/rhalbersma/xstd/actions/workflows/appleclang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/appleclang.yml)
 [![Clang-CL](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml)
 [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml)
-[![Coverage](https://codecov.io/gh/rhalbersma/xstd/branch/master/graph/badge.svg)](https://codecov.io/gh/rhalbersma/xstd)
+[![Coverage](https://codecov.io/gh/rhalbersma/xstd/branch/main/graph/badge.svg)](https://codecov.io/gh/rhalbersma/xstd)
 
 xstd is a header-only C++23 library for small standard-library extensions that can be implemented portably with stable compiler technology. It aims to prototype future-stdlib-style facilities without requiring experimental language features. See [doc/design.md](doc/design.md) for the design philosophy tying the headers together.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ include(FetchContent)
 FetchContent_Declare(
     xstd
     GIT_REPOSITORY https://github.com/rhalbersma/xstd.git
-    GIT_TAG master # or a release tag
+    GIT_TAG main # or a release tag
 )
 FetchContent_MakeAvailable(xstd)
 target_link_libraries(my_target PRIVATE xstd::xstd)


### PR DESCRIPTION
## Summary

- All 11 workflows' `push`/`pull_request` `branches: [ master ]` triggers never matched the actual default branch after the `master` -> `main` rename, so none of this CI has been running on `main` pushes or PRs:
  `appleclang.yml`, `clang-cl.yml`, `clang-format.yml`, `clang-tidy.yml`, `clang.yml`, `consumption.yml`, `coverage.yml`, `gcc.yml`, `mingw.yml`, `msvc.yml`, `sanitizers.yml`.
- Fixes the codecov badge in the README, which pointed at `branch/master` instead of `branch/main`.
- Fixes the `FetchContent` `GIT_TAG master # or a release tag` example in the README's consumption snippet.

## Test plan

- [x] All 11 edited workflow files validated with `yaml.safe_load`
- [x] No remaining `branches: [ master ]` in `.github/workflows/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGU9Giku3VLno5zSCNynCx)_