### PR TITLE
Add xstd::aligned_size, moved here from bit_set

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ xstd is a header-only C++23 library for small standard-library extensions that c
 | `<xstd/array.hpp>`       | `array_from_types` | Create an `array` from a type list | none |
 | `<xstd/cstdlib.hpp>`     | `sign`/`lsign`/`llsign`/`imaxsign` <br> `abs`/`labs`/`llabs`/`imaxabs` <br> `div`/`ldiv`/`lldiv`/`imaxdiv` <br> `div_t`/`ldiv_t`/`lldiv_t`/`imaxdiv_t` <br> `euclidean_div` and siblings <br> `floored_div` and siblings | `constexpr` support <br> `constexpr` support <br> `constexpr` support <br> `std::format` support, defaulted equality comparison <br> Euclidean division, at all 4 widths <br> Floored division, at all 4 widths | [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p2286r8](https://wg21.link/p2286r8) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) |
 | `<xstd/type_traits.hpp>` | `is_specialization_of` <br> `is_integral_constant` <br> `tagged_empty` <br> `optional_type` | Is a type a class template specialization? <br> Is a type an `integral_constant`? <br> A tagged empty type <br> An optional type | [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) <br> none <br> none <br> none |
-| `<xstd/utility.hpp>`     | `to_underlying`    | `std::integral_constant` overload | none |
+| `<xstd/utility.hpp>`     | `to_underlying` <br> `aligned_size` | `std::integral_constant` overload <br> Round a size up to a multiple of an alignment | none <br> none |
 
 ## Using xstd
 
@@ -69,6 +69,16 @@ using value = decltype(xstd::to_underlying(red{}));
 
 static_assert(value::value == 1);
 static_assert(std::is_same_v<value, std::integral_constant<unsigned, 1>>);
+```
+
+### Rounding a size up to an alignment
+
+`xstd::aligned_size` rounds a requested size up to the next multiple of an alignment, e.g. to turn a bit count into a whole number of storage blocks:
+
+```cpp
+#include <xstd/utility.hpp>
+
+static_assert(xstd::aligned_size(100, 64) == 128);
 ```
 
 ### Division helpers

--- a/include/xstd/utility.hpp
+++ b/include/xstd/utility.hpp
@@ -6,6 +6,7 @@
 #ifndef XSTD_UTILITY_HPP
 #define XSTD_UTILITY_HPP
 
+#include <cstddef>     // size_t
 #include <type_traits> // integral_constant, is_enum_v, underlying_type_t
 #include <utility>     // to_underlying
 
@@ -18,6 +19,14 @@ template<class Enum, Enum N>
         requires std::is_enum_v<Enum>
 {
         return std::integral_constant<std::underlying_type_t<Enum>, std::to_underlying(N)>();
+}
+
+// Rounds size up to the next multiple of alignment, e.g. so a requested
+// number of bits can be rounded up to a whole number of storage blocks.
+[[nodiscard]] constexpr auto aligned_size(std::size_t size, std::size_t alignment) noexcept
+        -> std::size_t
+{
+        return ((size - 1 + alignment) / alignment) * alignment;
 }
 
 } // namespace xstd

--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -41,4 +41,14 @@ BOOST_AUTO_TEST_CASE(ToUnderlyingType)
         XSTD_CONSTEXPR_CHECK_EQUAL(to_underlying(e5_<e5{}>()), static_cast<unsigned>(0));
 }
 
+BOOST_AUTO_TEST_CASE(AlignedSize)
+{
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 0, 8),  0);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 1, 8),  8);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 8, 8),  8);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 9, 8), 16);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(64, 8), 64);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(65, 8), 72);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -43,12 +43,14 @@ BOOST_AUTO_TEST_CASE(ToUnderlyingType)
 
 BOOST_AUTO_TEST_CASE(AlignedSize)
 {
-        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(0, 8), 0);
-        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(1, 8), 8);
-        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(8, 8), 8);
-        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(9, 8), 16);
+        // clang-format off
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 0, 8),  0);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 1, 8),  8);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 8, 8),  8);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 9, 8), 16);
         XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(64, 8), 64);
         XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(65, 8), 72);
+        // clang-format on
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -43,10 +43,10 @@ BOOST_AUTO_TEST_CASE(ToUnderlyingType)
 
 BOOST_AUTO_TEST_CASE(AlignedSize)
 {
-        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 0, 8),  0);
-        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 1, 8),  8);
-        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 8, 8),  8);
-        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size( 9, 8), 16);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(0, 8), 0);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(1, 8), 8);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(8, 8), 8);
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(9, 8), 16);
         XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(64, 8), 64);
         XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(65, 8), 72);
 }


### PR DESCRIPTION
## Summary

- Adds `xstd::aligned_size(size, alignment)` to `xstd/utility.hpp`, rounding a size up to the next multiple of an alignment.
- This function currently lives as a duplicate, colliding `xstd/utility.hpp` in [bit_set](https://github.com/rhalbersma/bit_set) — same relative path, same namespace, same include guard (`XSTD_UTILITY_HPP`), different contents than this repo's `to_underlying` overload. Homing it here removes that collision and lets bit_set take a real build dependency on xstd instead of vendoring its own copy. See [rhalbersma/bit_set#26](https://github.com/rhalbersma/bit_set/issues/26).
- Documents it in the header table and adds a short usage example, matching the existing `to_underlying` entry.

## Test plan

- [x] Added `AlignedSize` test case to `test/src/utility.cpp` covering the zero/exact-multiple/round-up boundary cases.
- [x] Verified `aligned_size`'s formula (unsigned-arithmetic edge case at `size == 0`) compiles and evaluates correctly under `-std=c++23` with `static_assert`.
- [ ] Full CI matrix / coverage / clang-tidy (not run locally; relying on the repo's CI).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HxuF9paPutMutJsoT91iUP)_