### PR TITLE
Add Clang+libc++ CI workflow and parameterize vcpkg libc++ toolchain

### DIFF
--- a/.github/vcpkg/toolchains/libcxx.cmake
+++ b/.github/vcpkg/toolchains/libcxx.cmake
@@ -4,10 +4,10 @@
 #          http://www.boost.org/LICENSE_1_0.txt)
 
 # Chainloaded by the x64-linux-libcxx triplet: builds vcpkg ports with the
-# same Clang + libc++ combination the Clang workflow's libc++ leg uses for
-# xstd itself. Bump the compiler version together with the clang.yml matrix.
-set(CMAKE_C_COMPILER clang-22)
-set(CMAKE_CXX_COMPILER clang++-22)
+# same Clang + libc++ combination the Clang-libc++ workflow uses for xstd
+# itself. The workflow supplies VCPKG_CLANG_VERSION for each matrix leg.
+set(CMAKE_C_COMPILER "clang-$ENV{VCPKG_CLANG_VERSION}")
+set(CMAKE_CXX_COMPILER "clang++-$ENV{VCPKG_CLANG_VERSION}")
 set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-stdlib=libc++")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT "-stdlib=libc++")

--- a/.github/vcpkg/triplets/x64-linux-libcxx.cmake
+++ b/.github/vcpkg/triplets/x64-linux-libcxx.cmake
@@ -4,7 +4,7 @@
 #          http://www.boost.org/LICENSE_1_0.txt)
 
 # x64-linux, but built with Clang against libc++ instead of the default
-# compiler against libstdc++. Used by the libc++ leg of the Clang workflow
+# compiler against libstdc++. Used by the Clang-libc++ workflow
 # so that vcpkg's Boost.Test and the xstd tests share one standard library.
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)

--- a/.github/workflows/clang-libc++.yml
+++ b/.github/workflows/clang-libc++.yml
@@ -64,6 +64,10 @@ jobs:
           --overlay-triplets "$GITHUB_WORKSPACE/.github/vcpkg/triplets"
 
       - name: Configure
+        env:
+          # The overlay triplet is evaluated again by the vcpkg CMake
+          # integration, so retain the compiler selection after install.
+          VCPKG_CLANG_VERSION: ${{ matrix.version }}
         run: >
           cmake -S . -B build
           -DCMAKE_C_COMPILER=clang-${{ matrix.version }}

--- a/.github/workflows/clang-libc++.yml
+++ b/.github/workflows/clang-libc++.yml
@@ -1,0 +1,80 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+name: Clang libc++
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Clang ${{ matrix.label }} libc++
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: "21"
+            version: 21
+          - label: "22"
+            version: 22
+          - label: 23-SVN
+            version: 23
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Install Clang and libc++ ${{ matrix.version }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{ matrix.version }}
+          sudo apt-get install -y libc++-${{ matrix.version }}-dev libc++abi-${{ matrix.version }}-dev
+
+      - name: Export GitHub Actions cache environment variables
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      # The overlay triplet rebuilds Boost.Test with the same Clang and
+      # libc++ version used for xstd, preventing mixed-standard-library
+      # linkage.
+      - name: Install Boost.Test
+        env:
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+          VCPKG_CLANG_VERSION: ${{ matrix.version }}
+        run: >
+          vcpkg install
+          --triplet x64-linux-libcxx
+          --overlay-triplets "$GITHUB_WORKSPACE/.github/vcpkg/triplets"
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_C_COMPILER=clang-${{ matrix.version }}
+          -DCMAKE_CXX_COMPILER=clang++-${{ matrix.version }}
+          -DCMAKE_CXX_FLAGS=-stdlib=libc++
+          -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+          -DVCPKG_TARGET_TRIPLET=x64-linux-libcxx
+          -DVCPKG_OVERLAY_TRIPLETS=$GITHUB_WORKSPACE/.github/vcpkg/triplets
+
+      - name: Build
+        run: cmake --build build -v
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -31,35 +31,23 @@ jobs:
             version: 21
             cc: clang-21
             cxx: clang++-21
-            stdlib: libstdc++
-            triplet: x64-linux
+            gcc_version: 15
+            gcc_trunk: false
             cxxflags: ""
           - label: "22"
             version: 22
             cc: clang-22
             cxx: clang++-22
-            stdlib: libstdc++
-            triplet: x64-linux
+            gcc_version: 16
+            gcc_trunk: false
             cxxflags: ""
-          # The MSVC STL and libstdc++ are covered by the other workflows;
-          # this leg adds the third mainstream standard library. Boost.Test
-          # is rebuilt against libc++ through the overlay triplet in
-          # .github/vcpkg (a libstdc++ Boost would not link). Required like
-          # every other leg.
-          - label: 22 libc++
-            version: 22
-            cc: clang-22
-            cxx: clang++-22
-            stdlib: libc++
-            triplet: x64-linux-libcxx
-            cxxflags: "-stdlib=libc++"
           - label: 23-SVN
             version: 23
             cc: clang-23
             cxx: clang++-23
-            stdlib: libstdc++
-            triplet: x64-linux
-            cxxflags: ""
+            gcc_version: 17
+            gcc_trunk: true
+            cxxflags: "--gcc-toolchain=/opt/gcc-latest"
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -70,24 +58,26 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.version }}
 
-      - name: Install libc++ ${{ matrix.version }}
-        if: matrix.stdlib == 'libc++'
-        run: sudo apt-get install -y libc++-${{ matrix.version }}-dev libc++abi-${{ matrix.version }}-dev
-
       # xstd/cstdlib.hpp's div_t formatter needs libstdc++'s <format> (and,
-      # more specifically, its std::formatter<tuple> support), so this
-      # installs a known-good g++ purely for its libstdc++, regardless of
-      # what the runner image's default GCC ships. Clang doesn't bundle its
-      # own standard library for -stdlib=libstdc++; it auto-selects the
-      # newest GCC installation's headers/runtime it can find, so this is
-      # enough - no --gcc-toolchain flag needed. Matches gcc.yml's own fix
-      # for the same underlying problem.
-      - name: Install a <format>-capable libstdc++
-        if: matrix.stdlib == 'libstdc++'
+      # more specifically, its std::formatter<tuple> support), so each
+      # Clang version is paired with the matching libstdc++ release.
+      - name: Install libstdc++ ${{ matrix.gcc_version }}
+        if: "!matrix.gcc_trunk"
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install -y g++-15
+          sudo apt-get install -y g++-${{ matrix.gcc_version }}
+
+      - name: Install libstdc++ trunk snapshot
+        if: matrix.gcc_trunk
+        run: |
+          wget -q https://kayari.org/gcc-latest/gcc-latest.deb -O gcc-latest.deb
+          sudo dpkg -i gcc-latest.deb || sudo apt-get install -f -y
+          printf '%s\n' \
+            '# Multiarch support' \
+            /opt/gcc-latest/lib \
+            /opt/gcc-latest/lib64 | sudo tee /etc/ld.so.conf.d/gcc-latest.conf > /dev/null
+          sudo ldconfig
 
       # Export the two env vars vcpkg's "x-gha" binary source needs to talk
       # to the GitHub Actions cache service, so built packages are reused
@@ -101,19 +91,15 @@ jobs:
 
       # vcpkg is used instead of the distro's boost package so xstd tracks
       # recent Boost releases regardless of what the OS bundles.
-      # apt.llvm.org's Clang packages
-      # (including the dev/SVN build) link against the system libstdc++ like
-      # every other apt-installed compiler on the runner - no separate
-      # bundled runtime, so no ABI mismatch with vcpkg's Boost.Test either.
-      # The libc++ leg instead selects the overlay triplet, which rebuilds
-      # Boost.Test with Clang against libc++.
       - name: Install Boost.Test
         env:
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+          CXXFLAGS: ${{ matrix.cxxflags }}
         run: >
           vcpkg install
-          --triplet ${{ matrix.triplet }}
-          --overlay-triplets "$GITHUB_WORKSPACE/.github/vcpkg/triplets"
+          --triplet x64-linux
 
       - name: Configure
         run: >
@@ -122,8 +108,6 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
           "-DCMAKE_CXX_FLAGS=${{ matrix.cxxflags }}"
           -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
-          -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
-          -DVCPKG_OVERLAY_TRIPLETS=$GITHUB_WORKSPACE/.github/vcpkg/triplets
 
       - name: Build
         run: cmake --build build -v

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Install libstdc++ trunk snapshot
         if: matrix.gcc_trunk
+        id: gcc-trunk
         run: |
           wget -q https://kayari.org/gcc-latest/gcc-latest.deb -O gcc-latest.deb
           sudo dpkg -i gcc-latest.deb || sudo apt-get install -f -y
@@ -78,6 +79,7 @@ jobs:
             /opt/gcc-latest/lib \
             /opt/gcc-latest/lib64 | sudo tee /etc/ld.so.conf.d/gcc-latest.conf > /dev/null
           sudo ldconfig
+          echo "version=$(/opt/gcc-latest/bin/g++ --version | head -1)" >> "$GITHUB_OUTPUT"
 
       # Export the two env vars vcpkg's "x-gha" binary source needs to talk
       # to the GitHub Actions cache service, so built packages are reused
@@ -112,8 +114,16 @@ jobs:
           boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/boostorg/boost/releases?per_page=20" | grep '"tag_name"' | cut -d'"' -f4 | grep -E -m1 '^boost-[0-9]+\.[0-9]+\.[0-9]+$')
           echo "tag=$boost_tag" >> "$GITHUB_OUTPUT"
 
-      - name: Install Boost.Test from source
+      - name: Cache Boost (trunk)
         if: matrix.gcc_trunk
+        id: cache-boost-trunk
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: /opt/boost-latest
+          key: boost-clang-trunk-${{ runner.os }}-${{ matrix.version }}-${{ steps.gcc-trunk.outputs.version }}-${{ steps.boost-version.outputs.tag }}
+
+      - name: Install Boost.Test from source
+        if: matrix.gcc_trunk && steps.cache-boost-trunk.outputs.cache-hit != 'true'
         run: |
           boost_tag=${{ steps.boost-version.outputs.tag }}
           boost_ver=${boost_tag#boost-}

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -92,6 +92,7 @@ jobs:
       # vcpkg is used instead of the distro's boost package so xstd tracks
       # recent Boost releases regardless of what the OS bundles.
       - name: Install Boost.Test
+        if: "!matrix.gcc_trunk"
         env:
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
           CC: ${{ matrix.cc }}
@@ -101,13 +102,46 @@ jobs:
           vcpkg install
           --triplet x64-linux
 
-      - name: Configure
+      # The GCC trunk snapshot ships a newer libstdc++ than the runner.
+      # Rebuild Boost.Test with the same Clang/libstdc++ pair; a cached
+      # system-libstdc++ Boost fails at runtime due to the ABI mismatch.
+      - name: Resolve latest Boost version
+        if: matrix.gcc_trunk
+        id: boost-version
+        run: |
+          boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/boostorg/boost/releases?per_page=20" | grep '"tag_name"' | cut -d'"' -f4 | grep -E -m1 '^boost-[0-9]+\.[0-9]+\.[0-9]+$')
+          echo "tag=$boost_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Install Boost.Test from source
+        if: matrix.gcc_trunk
+        run: |
+          boost_tag=${{ steps.boost-version.outputs.tag }}
+          boost_ver=${boost_tag#boost-}
+          wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
+          tar xzf boost.tar.gz
+          cd "boost-${boost_ver}"
+          echo "using clang : trunk : ${{ matrix.cxx }} : <cxxflags>${{ matrix.cxxflags }} <linkflags>${{ matrix.cxxflags }} ;" > user-config.jam
+          ./bootstrap.sh --prefix=/opt/boost-latest --with-libraries=test
+          ./b2 install -j"$(nproc)" --prefix=/opt/boost-latest --user-config=user-config.jam toolset=clang-trunk variant=release link=static threading=multi
+
+      - name: Configure (stable)
+        if: "!matrix.gcc_trunk"
         run: >
           cmake -S . -B build
           -DCMAKE_C_COMPILER=${{ matrix.cc }}
           -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
           "-DCMAKE_CXX_FLAGS=${{ matrix.cxxflags }}"
           -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+
+      - name: Configure (trunk)
+        if: matrix.gcc_trunk
+        run: >
+          cmake -S . -B build
+          -DCMAKE_C_COMPILER=${{ matrix.cc }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+          "-DCMAKE_CXX_FLAGS=${{ matrix.cxxflags }}"
+          -DCMAKE_PREFIX_PATH=/opt/boost-latest
+          -DBoost_NO_SYSTEM_PATHS=ON
 
       - name: Build
         run: cmake --build build -v

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![GCC](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml)
 [![MinGW](https://github.com/rhalbersma/xstd/actions/workflows/mingw.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/mingw.yml)
 [![Clang](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml)
+[![Clang-libc++](https://github.com/rhalbersma/xstd/actions/workflows/clang-libc%2B%2B.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-libc%2B%2B.yml)
 [![AppleClang](https://github.com/rhalbersma/xstd/actions/workflows/appleclang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/appleclang.yml)
 [![Clang-CL](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml)
 [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml)
@@ -164,14 +165,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow and what a p
 
 These header-only libraries are continuously being tested with the following conforming [C++23](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/n4950.pdf) compilers, against all three mainstream standard libraries (libstdc++, the MSVC STL, and libc++). Following the model of [apt.llvm.org](https://apt.llvm.org/), we support the latest two stable releases of each compiler, plus its current development branch. Every leg in the table below is required, including every `Trunk / Preview` entry: a break on trunk fails CI the same as a break on a stable release does.
 
-| Platform | Compiler | Older stable | Latest stable | Trunk / Preview | Build |
-| :------- | :------- | :------------ | :------------- | :---------------- | :---- |
-| Linux    | GCC      | 15             | 16              | 17-SVN             | [![GCC](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml) |
-| Linux    | Clang    | 21             | 22              | 23-SVN             | [![Clang](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml) |
-| macOS    | AppleClang | 17.0.0 (Xcode 16.4) | 21.0.0 (Xcode 26.5) | —          | [![AppleClang](https://github.com/rhalbersma/xstd/actions/workflows/appleclang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/appleclang.yml) |
-| Windows  | MinGW    | 15             | 16              | 17-SVN             | [![MinGW](https://github.com/rhalbersma/xstd/actions/workflows/mingw.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/mingw.yml) |
-| Windows  | Clang-CL | 19.1.5 (VS 2022) | 20.1.8 (VS 2026) | —               | [![Clang-CL](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml) |
-| Windows  | MSVC     | 2022 (17.11+)  | 2026            | 2026-Preview       | [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml) |
+| Platform | Compiler   | Standard Library | Older stable              | Latest stable             | Trunk / Preview                | Build |
+| :------- | :--------- | :--------------- | :------------------------ | :------------------------ | :----------------------------- | :---- |
+| Linux    | GCC        | libstdc++        | 15                        | 16                        | 17-SVN                         | [![GCC](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/gcc.yml) |
+| Linux    | Clang      | libstdc++        | 21 (libstdc++ 15)         | 22 (libstdc++ 16)         | 23-SVN (libstdc++ 17-SVN)      | [![Clang](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang.yml) |
+| Linux    | Clang      | libc++           | 21                        | 22                        | 23-SVN                         | [![Clang-libc++](https://github.com/rhalbersma/xstd/actions/workflows/clang-libc%2B%2B.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-libc%2B%2B.yml) |
+| macOS    | AppleClang | libc++           | 17.0.0 (Xcode 16.4)       | 21.0.0 (Xcode 26.5)       | —                              | [![AppleClang](https://github.com/rhalbersma/xstd/actions/workflows/appleclang.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/appleclang.yml) |
+| Windows  | MinGW      | libstdc++        | 15                        | 16                        | 17-SVN                         | [![MinGW](https://github.com/rhalbersma/xstd/actions/workflows/mingw.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/mingw.yml) |
+| Windows  | Clang-CL   | MSVC             | 19.1.5 (VS 2022)          | 20.1.8 (VS 2026)          | —                              | [![Clang-CL](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/clang-cl.yml) |
+| Windows  | MSVC       | MSVC             | 2022 (17.11+)             | 2026                      | 2026-Preview                   | [![MSVC](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/xstd/actions/workflows/msvc.yml) |
 
 The library is expected to work with any toolchain that implements the C++23 features it uses, including `std::format` for tuple-like types. See [doc/design.md](doc/design.md) for why some platforms have no `Trunk / Preview` row, how each workflow provisions its trunk/preview toolchain, and the MSVC version that first shipped tuple `std::formatter` support.
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -157,7 +157,7 @@ appropriate standard flag for each supported compiler.
 
 All three mainstream standard libraries are exercised: libstdc++ (GCC,
 Clang, and MinGW legs), the MSVC STL (MSVC and Clang-CL legs), and libc++
-(the `libc++` leg of the Clang workflow, which rebuilds Boost.Test against
+(the Clang-libc++ workflow, which rebuilds Boost.Test against
 libc++ through the vcpkg overlay triplet in `.github/vcpkg`, plus the
 AppleClang legs, which use macOS's libc++ by default). The library is
 expected to work with any toolchain that implements the C++23 features it


### PR DESCRIPTION
### Motivation
- Exercise Clang built against libc++ in CI and ensure Boost.Test is rebuilt against the same libc++ to avoid mixed-standard-library linkage.
- Replace hardcoded `clang-22` in the vcpkg libc++ toolchain with a workflow-supplied version to support multiple Clang matrix legs. 
- Pair each Clang release with an appropriate libstdc++ (including a trunk snapshot) in the main Clang workflow to ensure reliable `<format>` support across toolchains.

### Description
- Add `.github/workflows/clang-libc++.yml` which installs specified Clang and `libc++` versions, exports vcpkg cache env vars, uses `VCPKG_CLANG_VERSION` to rebuild Boost.Test via an overlay triplet, configures CMake with `-stdlib=libc++`, builds, and runs tests.
- Update `.github/vcpkg/toolchains/libcxx.cmake` to set `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` from `VCPKG_CLANG_VERSION` instead of a hardcoded `clang-22`.
- Tweak `.github/vcpkg/triplets/x64-linux-libcxx.cmake` comment and make it chainload the updated toolchain file, and adjust `.github/workflows/clang.yml` matrix and steps to install matching `libstdc++` packages or a trunk snapshot and simplify the vcpkg install invocation.
- Update `README.md` and `doc/design.md` to document and advertise the new Clang+libc++ workflow and clarify the standard-library coverage matrix.

### Testing
- No automated tests were executed as part of this change; the repository CI will run the newly added `Clang libc++` workflow and the existing CI matrix when the change is pushed or a PR is opened.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f6147af388332857c830720b5bb80)