### PR TITLE
Docs: tighten CONTRIBUTING and SECURITY, remove README duplicate, add gcovr branch exclusions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@ This repository enforces its quality bar through CI rather than through review d
 - **No new sanitizer failures.** The [sanitizers workflow](.github/workflows/sanitizers.yml) must stay green.
 - **The public headers stay self-sufficient.** Each header is compiled as its own translation unit (see `test/CMakeLists.txt`); don't rely on include order from another header.
 - **`clang-format` is clean.** The [Clang-Format workflow](.github/workflows/clang-format.yml) runs `clang-format --dry-run --Werror` over every header and test source against [`.clang-format`](.clang-format), so any diff fails the job. Run `clang-format -i` on changed files before pushing. A few spots that clang-format can't express (hand-laid-out test-data tables, one constrained-template constructor) are wrapped in `// clang-format off` / `// clang-format on`; don't add new guards without a comparable reason.
+- **Workflow files pass `actionlint`.** The [Actionlint workflow](.github/workflows/actionlint.yml) validates GitHub Actions syntax and expressions.
+- **The documented consumption methods work.** The [Consumption workflow](.github/workflows/consumption.yml) builds a consumer using `find_package`, `add_subdirectory`, and `FetchContent`.
+- **CodeQL analysis is clean.** The [CodeQL workflow](.github/workflows/codeql.yml) runs the C/C++ `security-extended` query suite.
 
 Match the surrounding code's style by eye where `.clang-format` doesn't have an opinion, including the Boost Software License header comment at the top of every source and workflow file.
 
@@ -48,6 +51,8 @@ ctest --test-dir build --output-on-failure
 gcovr --root . --exclude 'test/.*' --exclude 'build/.*' \
   --exclude-lines-by-pattern '^\s*assert\(' \
   --exclude-lines-by-pattern '=\s*default;' \
+  --exclude-branches-by-pattern '^\s*assert\(' \
+  --exclude-branches-by-pattern '^\s*.*=\s*default;' \
   --exclude-throw-branches --exclude-unreachable-branches \
   --print-summary --fail-under-line 100 --fail-under-branch 100
 ```

--- a/README.md
+++ b/README.md
@@ -157,10 +157,6 @@ Alternatively, install Boost.Test with your system package manager and point CMa
 - `test/src/` contains Boost.Test unit tests, with one executable generated per `.cpp` file.
 - `doc/` contains historical proposal documents and [design.md](doc/design.md), which explains the rationale behind API and CI/toolchain choices; none of it is the current public API.
 
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow and what a pull request must satisfy (full CI matrix, 100% line coverage, clean `clang-tidy`) before it can merge.
-
 ## Requirements
 
 These header-only libraries are continuously being tested with the following conforming [C++23](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/n4950.pdf) compilers, against all three mainstream standard libraries (libstdc++, the MSVC STL, and libc++). Following the model of [apt.llvm.org](https://apt.llvm.org/), we support the latest two stable releases of each compiler, plus its current development branch. Every leg in the table below is required, including every `Trunk / Preview` entry: a break on trunk fails CI the same as a break on a stable release does.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in xstd, please report it privately
+If you discover a security vulnerability in this project, please report it privately
 using [GitHub Security Advisories](https://github.com/rhalbersma/xstd/security/advisories/new)
 rather than opening a public issue.
 
-You should expect an initial response within a few days. Once a fix is
-available, a new release will be published and the advisory disclosed.
+This project is maintained by a single volunteer on a reasonable-effort basis.
+As such, please allow at least 90 days to work on a fix before public disclosure.


### PR DESCRIPTION
### Motivation

- Tighten and document the repository's required CI gates and coverage reproduction steps to ensure workflow validation and consistent coverage measurement.
- Clarify the security reporting policy and expected disclosure timeline for this single-maintainer project.

### Description

- Add new required checks to `CONTRIBUTING.md`: `actionlint`, the `Consumption` workflow, and CodeQL `security-extended` analysis. 
- Update the `gcovr` reproduction command in `CONTRIBUTING.md` to exclude branch patterns for `assert(...)` and `= default;` to avoid spurious branch-coverage failures. 
- Remove the redundant `Contributing` blurb from `README.md` so the single canonical `CONTRIBUTING.md` is authoritative. 
- Reword `SECURITY.md` to reference the project generically and add a note that the maintainer works on a reasonable-effort basis with a requested 90-day window before public disclosure.

### Testing

- No unit or functional tests were executed locally because this is a documentation-only change; repository CI workflows (including `actionlint`, `clang-format`, `clang-tidy`, coverage, and sanitizer jobs) are expected to run on the PR and validate the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fe6c7e5208332a350264e9c255783)