### PR TITLE
Make div_* operator== constexpr, noexcept, and [[nodiscard]]

### DIFF
--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -67,25 +67,25 @@ namespace xstd {
 struct div_t
 {
         int quot, rem;
-        friend bool operator==(div_t const&, div_t const&) = default;
+        [[nodiscard]] friend constexpr bool operator==(div_t const&, div_t const&) noexcept = default;
 };
 
 struct ldiv_t
 {
         long quot, rem;
-        friend bool operator==(ldiv_t const&, ldiv_t const&) = default;
+        [[nodiscard]] friend constexpr bool operator==(ldiv_t const&, ldiv_t const&) noexcept = default;
 };
 
 struct lldiv_t
 {
         long long quot, rem;
-        friend bool operator==(lldiv_t const&, lldiv_t const&) = default;
+        [[nodiscard]] friend constexpr bool operator==(lldiv_t const&, lldiv_t const&) noexcept = default;
 };
 
 struct imaxdiv_t
 {
         std::intmax_t quot, rem;
-        friend bool operator==(imaxdiv_t const&, imaxdiv_t const&) = default;
+        [[nodiscard]] friend constexpr bool operator==(imaxdiv_t const&, imaxdiv_t const&) noexcept = default;
 };
 
 namespace detail {


### PR DESCRIPTION
### Motivation
- Ensure the defaulted equality operators for division result structs can be used in constant expressions, are `noexcept`, and warn if their boolean result is ignored.

### Description
- Add `[[nodiscard]]`, `constexpr`, and `noexcept` to the friend defaulted `operator==` for `div_t`, `ldiv_t`, `lldiv_t`, and `imaxdiv_t` in `include/xstd/cstdlib.hpp`.

### Testing
- Built the project with `-std=c++20` and ran the unit test suite; compilation succeeded and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a609378046c83329f308c7e40a99f7d)