### PR TITLE
Re-upload coverage daily so a dropped report can't strand the badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,6 +18,15 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # The Codecov CLI only *queues* an upload: it exits successfully as soon
+  # as the report is handed over, and never learns whether Codecov managed
+  # to process it. A report dropped on Codecov's side therefore leaves main
+  # without coverage while every CI leg stays green, and the branch badge
+  # silently degrades to a grey "unknown" (this happened to 8bc5fee). The
+  # daily run re-uploads main's head so that state self-heals within a day
+  # instead of persisting until the next push.
+  schedule:
+    - cron: '30 3 * * *'
   workflow_dispatch:
 
 jobs:
@@ -144,7 +153,12 @@ jobs:
           plugins: noop
           disable_search: true
           use_oidc: true
-          fail_ci_if_error: false
+          # Fail loudly on a rejected or failed upload rather than leaving a
+          # green job with no coverage behind it. This can't catch a report
+          # that is accepted and then dropped during processing - hence the
+          # daily schedule above - but it does cover everything up to the
+          # hand-off.
+          fail_ci_if_error: true
 
       - name: Upload coverage report
         if: always()


### PR DESCRIPTION
### Motivation

The Codecov badge in the README has been showing a grey `unknown` rather than a green `100%`. The badge SVG reads `unknown` with `fill="#9f9f9f"` — this is "Codecov has no data for this branch", not "coverage is below target".

A branch badge resolves to the branch's head commit, and Codecov has nothing for `main`'s head, `8bc5fee`. That commit carries 51 check runs and **zero** commit statuses — no `codecov/project`, no `codecov/patch`. Every main commit before it has them, all at `100.00% (target 100.00%)`:

| commit | `codecov/project` |
| :-- | :-- |
| `8bc5fee` (HEAD) | none at all |
| `32facaf` | 100.00% (target 100.00%) |
| `16e9072` | 100.00% (target 100.00%) |
| `e22ea68` | 100.00% (target 100.00%) |
| `007aeb5` | 100.00% (target 100.00%) |
| `5823f52` | 100.00% (target 100.00%) |

Nothing in this repository was misconfigured. On `8bc5fee` the Coverage job passed its own `--fail-under-line 100 --fail-under-branch 100` gate, and the report it produced really is 100%: reproducing the gcovr invocation with the exact flag set yields `line-rate="1.0" branch-rate="1.0"` with no missed lines and no partial lines — which matters, because Codecov computes `hits/(hits+misses+partials)` and a single partial would have quietly pulled it under target. The existing `plugins: noop` / `disable_search: true` guards work. The CLI then logged `Upload queued for processing complete` for the correct SHA, and Codecov independently agreed the code was at 100% when it scored PR #96's head.

The report was lost on Codecov's side. The timeline on 2026-07-22 shows a processing backlog: PR #96's upload finished at `11:18Z` but its statuses were not posted until `16:12Z`, roughly five hours later. The push upload for `8bc5fee` was handed over at `11:29Z` and never landed at all.

Two properties let that pass unnoticed. The Codecov CLI only *queues* an upload — it exits successfully the moment the report is handed over and never learns whether processing completed — and `fail_ci_if_error` was `false`. So a dropped report leaves `main` uncovered while every CI leg stays green, and the badge stays grey until the next push to `main` happens to land a report.

### Description

- Add a daily `schedule` trigger (`30 3 * * *`) to the Coverage workflow, so `main`'s head is re-uploaded and this state self-heals within a day instead of persisting until the next push. The slot avoids the existing Monday crons used by Scorecard (`30 4`) and Toolchain Canary (`30 5`).
- Flip `fail_ci_if_error` to `true` on the Codecov upload step, so a rejected or failed upload turns the job red instead of leaving a green job with no coverage behind it. This cannot detect a report that is accepted and then dropped during processing — that is what the schedule is for — but it covers every failure up to the hand-off.

Both changes are commented in place so the reasoning survives next to the code.

### Testing

- The workflow YAML parses, and the parsed triggers (`push`, `pull_request`, `schedule`, `workflow_dispatch`), the cron expression, and the new `fail_ci_if_error` value were each verified.
- Separately from this diff, the Coverage workflow was re-dispatched on `main` to re-upload a report for `8bc5fee` and clear the current `unknown` badge.
- The gcovr exclusion behaviour underpinning the analysis above was reproduced locally against stand-ins for the excluded constructs (`assert(...)`, `= default;`, throw branches) to confirm the emitted Cobertura XML contains no misses and no partials.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajh3U4muFsE9u9JBbggrR1)_