### PR TITLE
Retry transient download failures across CI

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -27,9 +27,17 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      # The runner image writes APT::Acquire::Retries, but apt reads this
+      # setting from the Acquire group, so the image's value never takes
+      # effect. Set the key apt actually consults: without it a transient
+      # 5xx from a mirror or PPA fails the install on the first attempt,
+      # which is how one Launchpad brownout reddened three required legs.
+      - name: Make apt retry transient download failures
+        run: echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99-retries > /dev/null
+
       - name: Install Clang-Format 22
         run: |
-          wget https://apt.llvm.org/llvm.sh
+          wget --tries=3 --waitretry=5 --retry-on-http-error=429,500,502,503,504 https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 22
           sudo apt-get install -y clang-format-22

--- a/.github/workflows/clang-libc++.yml
+++ b/.github/workflows/clang-libc++.yml
@@ -45,9 +45,17 @@ jobs:
 
       # See the matching step in clang.yml for why the suite is named
       # directly instead of letting llvm.sh derive it.
+      # The runner image writes APT::Acquire::Retries, but apt reads this
+      # setting from the Acquire group, so the image's value never takes
+      # effect. Set the key apt actually consults: without it a transient
+      # 5xx from a mirror or PPA fails the install on the first attempt,
+      # which is how one Launchpad brownout reddened three required legs.
+      - name: Make apt retry transient download failures
+        run: echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99-retries > /dev/null
+
       - name: Install Clang and libc++ ${{ matrix.version }}
         run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+          wget -qO- --tries=3 --waitretry=5 --retry-on-http-error=429,500,502,503,504 https://apt.llvm.org/llvm-snapshot.gpg.key \
             | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
           codename=$(lsb_release -cs)
           sudo add-apt-repository -y "deb https://apt.llvm.org/${codename}/ llvm-toolchain-${codename}${{ matrix.llvm_suffix }} main"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -27,9 +27,17 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      # The runner image writes APT::Acquire::Retries, but apt reads this
+      # setting from the Acquire group, so the image's value never takes
+      # effect. Set the key apt actually consults: without it a transient
+      # 5xx from a mirror or PPA fails the install on the first attempt,
+      # which is how one Launchpad brownout reddened three required legs.
+      - name: Make apt retry transient download failures
+        run: echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99-retries > /dev/null
+
       - name: Install Clang 22 and clang-tidy 22
         run: |
-          wget https://apt.llvm.org/llvm.sh
+          wget --tries=3 --waitretry=5 --retry-on-http-error=429,500,502,503,504 https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 22
           sudo apt-get install -y clang-tidy-22

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -69,9 +69,17 @@ jobs:
       # Install versioned packages rather than the unversioned
       # metapackages, which lag the rename the same way and would drag in a
       # clang-N the development suite no longer carries.
+      # The runner image writes APT::Acquire::Retries, but apt reads this
+      # setting from the Acquire group, so the image's value never takes
+      # effect. Set the key apt actually consults: without it a transient
+      # 5xx from a mirror or PPA fails the install on the first attempt,
+      # which is how one Launchpad brownout reddened three required legs.
+      - name: Make apt retry transient download failures
+        run: echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99-retries > /dev/null
+
       - name: Install Clang ${{ matrix.version }}
         run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+          wget -qO- --tries=3 --waitretry=5 --retry-on-http-error=429,500,502,503,504 https://apt.llvm.org/llvm-snapshot.gpg.key \
             | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
           codename=$(lsb_release -cs)
           sudo add-apt-repository -y "deb https://apt.llvm.org/${codename}/ llvm-toolchain-${codename}${{ matrix.llvm_suffix }} main"
@@ -96,7 +104,7 @@ jobs:
         if: matrix.gcc_trunk
         id: gcc-trunk
         run: |
-          wget -q https://kayari.org/gcc-latest/gcc-latest.deb -O gcc-latest.deb
+          wget -q --tries=3 --waitretry=5 --retry-on-http-error=429,500,502,503,504 https://kayari.org/gcc-latest/gcc-latest.deb -O gcc-latest.deb
           sudo dpkg -i gcc-latest.deb || sudo apt-get install -f -y
           printf '%s\n' \
             '# Multiarch support' \
@@ -146,7 +154,7 @@ jobs:
         if: matrix.gcc_trunk
         id: boost-version
         run: |
-          boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/boostorg/boost/releases?per_page=20" | grep '"tag_name"' | cut -d'"' -f4 | grep -E -m1 '^boost-[0-9]+\.[0-9]+\.[0-9]+$')
+          boost_tag=$(curl -fsSL --retry 3 --retry-delay 2 -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/boostorg/boost/releases?per_page=20" | grep '"tag_name"' | cut -d'"' -f4 | grep -E -m1 '^boost-[0-9]+\.[0-9]+\.[0-9]+$')
           echo "tag=$boost_tag" >> "$GITHUB_OUTPUT"
 
       - name: Cache Boost (trunk)
@@ -162,7 +170,7 @@ jobs:
         run: |
           boost_tag=${{ steps.boost-version.outputs.tag }}
           boost_ver=${boost_tag#boost-}
-          wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
+          wget -q --tries=3 --waitretry=5 --retry-on-http-error=429,500,502,503,504 "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
           tar xzf boost.tar.gz
           cd "boost-${boost_ver}"
           echo "using clang : trunk : ${{ matrix.cxx }} : <cxxflags>${{ matrix.cxxflags }} <linkflags>${{ matrix.cxxflags }} ;" > user-config.jam

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      # The runner image writes APT::Acquire::Retries, but apt reads this
+      # setting from the Acquire group, so the image's value never takes
+      # effect. Set the key apt actually consults: without it a transient
+      # 5xx from a mirror or PPA fails the install on the first attempt,
+      # which is how one Launchpad brownout reddened three required legs.
+      - name: Make apt retry transient download failures
+        run: echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99-retries > /dev/null
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
         with:

--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -27,6 +27,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      # The runner image writes APT::Acquire::Retries, but apt reads this
+      # setting from the Acquire group, so the image's value never takes
+      # effect. Set the key apt actually consults: without it a transient
+      # 5xx from a mirror or PPA fails the install on the first attempt,
+      # which is how one Launchpad brownout reddened three required legs.
+      - name: Make apt retry transient download failures
+        run: echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99-retries > /dev/null
+
       - name: Install GCC 15
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,6 +37,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      # The runner image writes APT::Acquire::Retries, but apt reads this
+      # setting from the Acquire group, so the image's value never takes
+      # effect. Set the key apt actually consults: without it a transient
+      # 5xx from a mirror or PPA fails the install on the first attempt,
+      # which is how one Launchpad brownout reddened three required legs.
+      - name: Make apt retry transient download failures
+        run: echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99-retries > /dev/null
+
       - name: Install GCC 15 and gcovr
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -47,6 +47,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      # The runner image writes APT::Acquire::Retries, but apt reads this
+      # setting from the Acquire group, so the image's value never takes
+      # effect. Set the key apt actually consults: without it a transient
+      # 5xx from a mirror or PPA fails the install on the first attempt,
+      # which is how one Launchpad brownout reddened three required legs.
+      - name: Make apt retry transient download failures
+        run: echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99-retries > /dev/null
+
       - name: Install GCC ${{ matrix.version }} (stable)
         if: "!matrix.trunk"
         run: |
@@ -65,7 +73,7 @@ jobs:
         if: matrix.trunk
         id: gcc-trunk
         run: |
-          wget -q https://kayari.org/gcc-latest/gcc-latest.deb -O gcc-latest.deb
+          wget -q --tries=3 --waitretry=5 --retry-on-http-error=429,500,502,503,504 https://kayari.org/gcc-latest/gcc-latest.deb -O gcc-latest.deb
           sudo dpkg -i gcc-latest.deb || sudo apt-get install -f -y
           sudo ln -sf /opt/gcc-latest/bin/gcc        /usr/bin/${{ matrix.cc }}
           sudo ln -sf /opt/gcc-latest/bin/g++        /usr/bin/${{ matrix.cxx }}
@@ -127,7 +135,7 @@ jobs:
         run: |
           # /releases/latest can return a beta (boostorg doesn't always flag
           # them as prerelease), so list releases and keep strict boost-X.Y.Z
-          boost_tag=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/boostorg/boost/releases?per_page=20" | grep '"tag_name"' | cut -d'"' -f4 | grep -E -m1 '^boost-[0-9]+\.[0-9]+\.[0-9]+$')
+          boost_tag=$(curl -fsSL --retry 3 --retry-delay 2 -H "Authorization: Bearer ${{ github.token }}" "https://api.github.com/repos/boostorg/boost/releases?per_page=20" | grep '"tag_name"' | cut -d'"' -f4 | grep -E -m1 '^boost-[0-9]+\.[0-9]+\.[0-9]+$')
           echo "tag=$boost_tag" >> "$GITHUB_OUTPUT"
 
       - name: Cache Boost (trunk)
@@ -143,7 +151,7 @@ jobs:
         run: |
           boost_tag=${{ steps.boost-version.outputs.tag }}
           boost_ver=${boost_tag#boost-}
-          wget -q "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
+          wget -q --tries=3 --waitretry=5 --retry-on-http-error=429,500,502,503,504 "https://github.com/boostorg/boost/releases/download/${boost_tag}/boost-${boost_ver}-b2-nodocs.tar.gz" -O boost.tar.gz
           tar xzf boost.tar.gz
           cd "boost-${boost_ver}"
           echo "using gcc : trunk : ${{ matrix.cxx }} ;" > user-config.jam

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -53,7 +53,7 @@ jobs:
         id: winlibs
         shell: bash
         run: |
-          releases=$(curl -fsSL -H "Authorization: Bearer ${{ github.token }}" \
+          releases=$(curl -fsSL --retry 3 --retry-delay 2 -H "Authorization: Bearer ${{ github.token }}" \
             "https://api.github.com/repos/brechtsanders/winlibs_mingw/releases?per_page=100")
 
           if [ "${{ matrix.snapshot }}" = "true" ]; then
@@ -111,7 +111,7 @@ jobs:
         if: steps.winlibs.outputs.found == 'true' && steps.cache-winlibs.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -fsSL "${{ steps.winlibs.outputs.url }}" -o winlibs.7z
+          curl -fsSL --retry 3 --retry-delay 2 "${{ steps.winlibs.outputs.url }}" -o winlibs.7z
           7z x winlibs.7z -oC:/winlibs_extract
           mv C:/winlibs_extract/mingw64 C:/winlibs
           rm -rf C:/winlibs_extract

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -37,6 +37,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      # The runner image writes APT::Acquire::Retries, but apt reads this
+      # setting from the Acquire group, so the image's value never takes
+      # effect. Set the key apt actually consults: without it a transient
+      # 5xx from a mirror or PPA fails the install on the first attempt,
+      # which is how one Launchpad brownout reddened three required legs.
+      - name: Make apt retry transient download failures
+        run: echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99-retries > /dev/null
+
       - name: Install GCC 15
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
### Motivation

A Launchpad brownout reddened three required legs on a documentation-only PR — `GCC 15`, `GCC 15 UBSan` and `GCC 15 gcovr` — each with `503 Service Unavailable` from `ppa.launchpadcontent.net` partway through `apt-get install`:

```
E: Failed to fetch .../pool/main/g/gcc-15/g++-15_15.2.0-...deb  503  Service Unavailable
E: Failed to fetch .../pool/main/g/gcc-16/libtsan2_16-...deb    503  Service Unavailable
E: Unable to fetch some archives
Fetched 51.0 MB in 5min 33s (153 kB/s)
```

Nothing retried, so all three needed manual re-runs. An audit of every network fetch in the workflows found three unprotected mechanisms.

**apt had no effective retry at all.** The runner image writes `APT::Acquire::Retries "10"` to `/etc/apt/apt.conf.d/80-retries`, but [`apt.conf(5)`](https://manpages.ubuntu.com/manpages/noble/en/man5/apt.conf.5.html) documents the option in the **Acquire** group as `Acquire::Retries`, and `apt-config` confirms the two are distinct entries rather than aliases:

```
$ apt-config -o 'Acquire::Retries=7' dump | grep -i retries
Acquire::Retries "7";
$ apt-config -o 'APT::Acquire::Retries=9' dump | grep -i retries
APT::Acquire::Retries "9";
```

So the image's intended ten retries never apply.

**`curl` does not retry by default**, and none of the four call sites asked it to.

**`wget` looks protected and is not.** Its default is `--tries=20`, but those cover connection-level failures; an HTTP 5xx response is fatal on the first attempt unless `--retry-on-http-error` is passed — precisely the error hit here.

### Description

- **apt** — each of the nine Linux jobs writes `Acquire::Retries "5"` to `/etc/apt/apt.conf.d/99-retries` before its first apt use. One step per job covers every `apt-get` in that job *and* the `apt-get update` that `add-apt-repository` runs internally, instead of a flag on eighteen call sites.
- **curl** — `--retry 3 --retry-delay 2` on all four: the Boost release lookups in `gcc.yml` and `clang.yml`, and the WinLibs release lookup and `.7z` download in `mingw.yml`. With `--retry`, curl treats 429 and 5xx as transient.
- **wget** — `--tries=3 --waitretry=5 --retry-on-http-error=429,500,502,503,504` on all eight: `llvm.sh` (×2), the LLVM signing key (×2), `gcc-latest.deb` (×2) and the Boost tarball (×2).

Deliberately left alone:

- `pip` already defaults to `--retries 5`, and vcpkg retries its own downloads and is additionally backed by the `x-gha` binary cache.
- The two `Invoke-WebRequest` HEAD probes against `aka.ms` in `clang-cl.yml` and `msvc.yml`. PowerShell has no built-in retry, and these only probe preview-channel availability, so a retry loop is more machinery than the exposure warrants.

No third-party retry action is introduced, which keeps the supply-chain surface unchanged for a repository that SHA-pins every action and runs OpenSSF Scorecard.

### Testing

- Both flag strings were smoke-tested against the real endpoints before committing: `wget --tries=3 --waitretry=5 --retry-on-http-error=429,500,502,503,504 --spider https://apt.llvm.org/llvm.sh` and `curl -fsSL --retry 3 --retry-delay 2 https://api.github.com` both succeed, confirming the options are accepted as written.
- All sixteen workflow files still parse, and a placement check confirms the new apt step precedes the first `apt-get`/`add-apt-repository` step in each of the nine jobs.
- A follow-up scan finds no remaining `wget` or `curl` invocation in `.github/workflows/` without retry flags.
- CI on this PR exercises every touched workflow.

Worth setting expectations: this raises the floor, it does not eliminate re-runs. The incident that prompted it involved a mirror degraded for the full 3–5 minutes of each fetch, and a brownout that long can still exhaust three retries. The aim is to absorb brief blips, which are the common case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajh3U4muFsE9u9JBbggrR1)_