### PR TITLE
Harmonize xstd's CI config with tabula's

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,8 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
 ---
 Language: Cpp
 Standard: Latest

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,8 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
 ---
 # Static analysis for the public headers, run by the Clang-Tidy workflow
 # over the generated header self-sufficiency translation units (the

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25.1'
           cache: false

--- a/.github/workflows/apple-clang.yml
+++ b/.github/workflows/apple-clang.yml
@@ -40,9 +40,9 @@ jobs:
       DEVELOPER_DIR: ${{ matrix.developer_dir }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Report toolchain version
+      - name: Report toolchain versions
         run: |
           xcodebuild -version
           clang++ --version

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Run the complete compiler workflows weekly so dynamic trunk/preview
+  # Run the complete compiler workflows weekly so dynamic development
   # toolchains and mutable runner images are checked even without a push.
   gcc:
     uses: ./.github/workflows/gcc.yml

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -59,7 +59,7 @@ jobs:
             preview_channel: true
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Cache the preview installer payload by channel-manifest revision.
       # Without this, the optional toolset would be downloaded on every run.
@@ -76,7 +76,7 @@ jobs:
 
       - name: Cache VS Installer package downloads
         if: matrix.preview_channel
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: C:\ProgramData\Microsoft\VisualStudio\Packages
           key: vs-preview-packages-${{ runner.os }}-${{ steps.preview-channel.outputs.version }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The runner image writes APT::Acquire::Retries, but apt reads this
       # setting from the Acquire group, so the image's value never takes

--- a/.github/workflows/clang-libc++.yml
+++ b/.github/workflows/clang-libc++.yml
@@ -41,7 +41,7 @@ jobs:
             llvm_suffix: ""
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # See the matching step in clang.yml for why the suite is named
       # directly instead of letting llvm.sh derive it.

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The runner image writes APT::Acquire::Retries, but apt reads this
       # setting from the Acquire group, so the image's value never takes
@@ -72,9 +72,18 @@ jobs:
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         run: vcpkg install --triplet x64-linux
 
+      # Debug rather than an unset build type: leaving it unset already
+      # leaves NDEBUG undefined, which is what matters here, but it does so
+      # by accident and is one preset change away from silently becoming
+      # Release. CMake's Release adds -DNDEBUG, which rewrites every
+      # assert(...) to ((void)0) before it reaches the AST - 49 of them
+      # across cstdlib.hpp and utility.hpp - which would disable
+      # bugprone-assert-side-effect outright and strip the assertions
+      # clang-analyzer-* uses to prune infeasible paths. Matches codeql.yml.
       - name: Configure
         run: >
           cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=Debug
           -DCMAKE_C_COMPILER=clang-22
           -DCMAKE_CXX_COMPILER=clang++-22
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
@@ -86,6 +95,24 @@ jobs:
       # check selection and per-check suppressions live in .clang-tidy;
       # WarningsAsErrors there makes any finding fail this job.
       - name: Run clang-tidy over the public headers
-        run: >
-          run-clang-tidy-22 -quiet -p build
-          "$GITHUB_WORKSPACE/build/test/header_self_sufficiency/.*"
+        run: |
+          run-clang-tidy-22 -quiet -p build \
+            "$GITHUB_WORKSPACE/build/test/header_self_sufficiency/.*" \
+            2>&1 | tee clang-tidy-report.txt
+
+      - name: Publish clang-tidy summary
+        if: always()
+        run: |
+          {
+            echo '### clang-tidy findings'
+            echo '```'
+            grep -E ': (error|warning):' clang-tidy-report.txt || echo 'No findings.'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload clang-tidy report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: clang-tidy-report
+          path: clang-tidy-report.txt

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -56,7 +56,7 @@ jobs:
             cxxflags: "--gcc-toolchain=/opt/gcc-latest"
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Select the apt.llvm.org suite directly rather than going through
       # llvm.sh. That script maps a version to a suite from a hardcoded

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The runner image writes APT::Acquire::Retries, but apt reads this
       # setting from the Acquire group, so the image's value never takes
@@ -41,7 +41,7 @@ jobs:
         run: echo 'Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/99-retries > /dev/null
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: c-cpp
           queries: security-extended
@@ -71,9 +71,19 @@ jobs:
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
         run: vcpkg install --triplet x64-linux
 
+      # Debug rather than an unset build type: leaving it unset already
+      # leaves NDEBUG undefined, which is what matters here, but it does so
+      # by accident and is one preset change away from silently becoming
+      # Release. CMake's Release adds -DNDEBUG, which rewrites every
+      # assert(...) to ((void)0) before it reaches the AST - 49 of them
+      # across cstdlib.hpp and utility.hpp - and CodeQL's C/C++ extractor
+      # runs alongside the compiler front-end, so it gains nothing from the
+      # optimization level while losing all of that code. Matches
+      # sanitizers.yml/coverage.yml, and clang-tidy.yml for the same reason.
       - name: Configure
         run: >
           cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=Debug
           -DCMAKE_C_COMPILER=gcc-15
           -DCMAKE_CXX_COMPILER=g++-15
           -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
@@ -82,6 +92,6 @@ jobs:
         run: cmake --build build -v
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:c-cpp"

--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The runner image writes APT::Acquire::Retries, but apt reads this
       # setting from the Acquire group, so the image's value never takes

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The runner image writes APT::Acquire::Retries, but apt reads this
       # setting from the Acquire group, so the image's value never takes

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -45,7 +45,7 @@ jobs:
             trunk: true
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The runner image writes APT::Acquire::Retries, but apt reads this
       # setting from the Acquire group, so the image's value never takes

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -39,7 +39,7 @@ jobs:
             snapshot: true
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # WinLibs (https://winlibs.com) publishes standalone, versioned
       # GCC + MinGW-w64 + UCRT builds as dated GitHub releases rather than a
@@ -126,7 +126,7 @@ jobs:
         if: steps.winlibs.outputs.found == 'true'
         run: echo "C:\winlibs\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8NoBOM -Append
 
-      - name: Report toolchain version
+      - name: Report toolchain versions
         if: steps.winlibs.outputs.found == 'true'
         run: |
           gcc --version

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -44,7 +44,7 @@ jobs:
             preview_channel: true
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The preview toolset's payload (~10 min of the ~15-20 min this leg
       # otherwise takes) is re-downloaded from Microsoft's CDN on every run,
@@ -69,7 +69,7 @@ jobs:
 
       - name: Cache VS Installer package downloads
         if: matrix.preview_channel
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: C:\ProgramData\Microsoft\VisualStudio\Packages
           key: vs-preview-packages-${{ runner.os }}-${{ steps.preview-channel.outputs.version }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -35,7 +35,7 @@ jobs:
             env: UBSAN_OPTIONS=print_stacktrace=1
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The runner image writes APT::Acquire::Retries, but apt reads this
       # setting from the Acquire group, so the image's value never takes

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,7 +31,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -54,6 +54,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF results to code scanning
-        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
 /build/
 /.vscode/
 *.info


### PR DESCRIPTION
The other half of a pass over the config files xstd and tabula share ([rhalbersma/tabula#40](https://github.com/rhalbersma/tabula/pull/40) is the tabula side). xstd is the canonical source for that skeleton, but three of these improvements were made in tabula first, so they land here to become the version the other projects copy.

## `codeql.yml` and `clang-tidy.yml` now configure `Debug`

Neither set a build type at all. That already left `NDEBUG` undefined — the property that actually matters — but by accident, and it's one preset change away from silently becoming Release.

Release adds `-DNDEBUG`, which rewrites every `assert(...)` to `((void)0)` before it reaches the AST. xstd has **49** of them, across `cstdlib.hpp` (47) and `utility.hpp` (2). That would disable `bugprone-assert-side-effect` outright and strip the assertions `clang-analyzer-*` uses to prune infeasible paths, and would hide the same code from CodeQL's extractor — which runs alongside the compiler front-end and gains nothing from the optimization level either way.

Stating `Debug` explicitly makes the intent — *analyze with assertions live* — match what `sanitizers.yml` and `coverage.yml` already do.

## `clang-tidy.yml` gains reporting

From tabula: the run is teed to `clang-tidy-report.txt`, findings are published to the step summary, and the report is uploaded as an artifact. Previously a failure meant reading raw job logs.

## Four action pins move up

To the newer SHAs tabula already carries — `actions/checkout` v7.0.1, `actions/setup-go` v7.0.0, `actions/cache` v6.1.0, `github/codeql-action` v4.37.3. Pure dependabot timing; the two repos had drifted apart by a few releases in xstd's disfavour.

## Consistency

`apple-clang.yml` and `mingw.yml` said "Report toolchain version" where every other workflow says "versions"; `canary.yml` described its weekly run as covering "trunk/preview" toolchains rather than development ones; and `.gitignore`, `.clang-tidy` and `.clang-format` gained the Boost license header every other file in the repository carries.

## Deliberately not included: `-Wa,-mbig-obj`

`568cf00` dropped it as dead configuration because no CI leg built GCC-on-Windows, noting it should return "together with an MSYS2 leg if MinGW support ever becomes a goal" — and `480fa0a` added a MinGW leg **the next day**. The stated precondition has been met since 2026-07-17.

It's still left out, because two weeks of green MinGW runs without it is better evidence than that commit's reasoning was. It should come back only if a leg actually overflows the COFF section limit. tabula's PR drops it for the same reason.

## Testing

All workflows parse as YAML and pass `actionlint` (only finding is the pre-existing `macos-26` label, unknown to actionlint 1.7.7). `.clang-format` and `.clang-tidy` verified to still parse after gaining their headers. No library code changed.

⚠️ The Debug switch is not guaranteed to be a no-op: with `WarningsAsErrors: '*'`, bringing 49 assertions into the analyzer's view at once may surface new findings. If it goes red I'll propose fixes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaQxX6sFVU4bzZk7UcDory)_