### PR TITLE
Cover aligned_size at SIZE_MAX with a non-power-of-two alignment

### DIFF
--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -53,6 +53,12 @@ BOOST_AUTO_TEST_CASE(AlignedSize)
         XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(65, 8), 72);
         XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(std::numeric_limits<std::size_t>::max() - 7, 8), std::numeric_limits<std::size_t>::max() - 7);
         XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(std::numeric_limits<std::size_t>::max() - 8, 8), std::numeric_limits<std::size_t>::max() - 7);
+        // SIZE_MAX is divisible by 3, so this is the already-aligned case at
+        // the very top of the range, with a non-power-of-two alignment. It
+        // pins the contract as "the rounded result must fit", which is wider
+        // than the (size + alignment - 1) rounding idiom can honour: that
+        // form wraps to 0 here.
+        XSTD_CONSTEXPR_CHECK_EQUAL(aligned_size(std::numeric_limits<std::size_t>::max(), 3), std::numeric_limits<std::size_t>::max());
         // clang-format on
 }
 


### PR DESCRIPTION
### Motivation

Every existing `aligned_size` case uses a power-of-two alignment, so the widest part of the contract goes unpinned.

`SIZE_MAX` is divisible by 3, which makes `(SIZE_MAX, 3)` the already-aligned case at the very top of the range with an alignment that is not a power of two. That combination is exactly what distinguishes the current implementation from the usual rounding idiom:

```cpp
(size + alignment - 1) / alignment * alignment   // returns 0 here: size + 2 wraps
aligned_size(SIZE_MAX, 3)                        // returns SIZE_MAX
```

The contract is "the rounded result must fit", not "the rounded result plus `alignment - 1` must fit", and this is the case that says so. Nothing currently stops a future rewrite to that idiom from silently narrowing it.

### Description

One test case, plus a comment recording why it exists. **The implementation is unchanged.**

An earlier revision of this PR also restructured `aligned_size`. That was dropped after measurement: the original early-return shape is the one Clang collapses to `lea 63(%rdi),%rax ; and $-64,%rax` for a constant power-of-two alignment, and every restructuring tried lost that peephole — 3 instructions to 8, identically at `-O1`, `-O2`, `-O3`, `-Os` and `-Ofast`. GCC was near-indifferent (8 to 9, a register-to-register move). The forms are mathematically identical, including under wraparound, so it is a missed optimization rather than a genuine cost — but not one worth paying here.

### Testing

- The new case verified as a `static_assert` against the unchanged implementation, so it holds under constant evaluation as well as at runtime, alongside the six existing cases.
- Independently confirmed `SIZE_MAX % 3 == 0`, and that `(size + alignment - 1) / alignment * alignment` returns `0` for this input where `aligned_size` returns `SIZE_MAX`.
- Compiled under `-std=c++2b` with the GNU warning set the test target uses (`-Wall -Wextra -Wpedantic -Wconversion -Wshadow -Wsign-conversion -pedantic-errors`): no diagnostics.
- `clang-format --dry-run --Werror`: clean.