### PR TITLE
Promote detail::magnitude to the public API as uabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ xstd is a header-only C++23 library for small standard-library extensions that c
 | Header                   | Additions          | Description | Reference |
 | :-----                   | :--------          | :---------- | :-------- |
 | `<xstd/array.hpp>`       | `array_from_types` | Create an `array` from a type list | none |
-| `<xstd/cstdlib.hpp>`     | `sign`/`lsign`/`llsign`/`imaxsign` <br> `abs`/`labs`/`llabs`/`imaxabs` <br> `div`/`ldiv`/`lldiv`/`imaxdiv` <br> `div_t`/`ldiv_t`/`lldiv_t`/`imaxdiv_t` <br> `euclidean_div` and siblings <br> `floored_div` and siblings | `constexpr` support <br> `constexpr` support <br> `constexpr` support <br> `std::format` support, defaulted equality comparison <br> Euclidean division, at all 4 widths <br> Floored division, at all 4 widths | [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p2286r8](https://wg21.link/p2286r8) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) |
+| `<xstd/cstdlib.hpp>`     | `sign`/`lsign`/`llsign`/`imaxsign` <br> `abs`/`labs`/`llabs`/`imaxabs` <br> `uabs`/`ulabs`/`ullabs`/`uimaxabs` <br> `div`/`ldiv`/`lldiv`/`imaxdiv` <br> `div_t`/`ldiv_t`/`lldiv_t`/`imaxdiv_t` <br> `euclidean_div` and siblings <br> `floored_div` and siblings | `constexpr` support <br> `constexpr` support <br> Total `\|x\|`, returning the unsigned type <br> `constexpr` support <br> `std::format` support, defaulted equality comparison <br> Euclidean division, at all 4 widths <br> Floored division, at all 4 widths | [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Rust `unsigned_abs`](https://doc.rust-lang.org/std/primitive.i32.html#method.unsigned_abs) (no C++ equivalent) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p2286r8](https://wg21.link/p2286r8) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) |
 | `<xstd/type_traits.hpp>` | `is_specialization_of` <br> `is_integral_constant` <br> `tagged_empty` <br> `optional_type` | Is a type a class template specialization? <br> Is a type an `integral_constant`? <br> A tagged empty type <br> An optional type | [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) <br> none <br> none <br> none |
 | `<xstd/utility.hpp>`     | `to_underlying` <br> `aligned_size` | `std::integral_constant` overload <br> Round a size up to a multiple of an alignment | none <br> none |
 
@@ -85,6 +85,23 @@ static_assert(std::is_same_v<value, std::integral_constant<unsigned, 1>>);
 
 static_assert(xstd::aligned_size(100, 64) == 128);
 ```
+
+### Absolute value without a precondition
+
+`xstd::abs` mirrors `<cstdlib>`: it returns the signed type, so the most negative value is outside its contract. `xstd::uabs` returns the unsigned type, which can represent that magnitude, and so has no precondition:
+
+```cpp
+#include <climits>
+#include <xstd/cstdlib.hpp>
+
+static_assert(xstd::abs(-2) == 2);
+static_assert(xstd::uabs(-2) == 2u);
+
+// |INT_MIN| is one past INT_MAX, so only the unsigned form can return it
+static_assert(xstd::uabs(INT_MIN) == static_cast<unsigned>(INT_MAX) + 1u);
+```
+
+`ulabs`, `ullabs`, and `uimaxabs` cover `long`, `long long`, and `intmax_t`, following the same naming as `labs`/`llabs`/`imaxabs`.
 
 ### Division helpers
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -64,6 +64,32 @@ the `imax`-prefixed names sidestep that regardless of platform, matching
 how the public family already uses distinct names (`abs`/`labs`/`llabs`/
 `imaxabs`) rather than an overload set.
 
+### `xstd::uabs`/`xstd::ulabs`/`xstd::ullabs`/`xstd::uimaxabs`
+
+`abs` cannot be total: `|x|` for the most negative value of a signed type is
+one past that type's maximum, so there is no signed result to return. The
+standard's answer is undefined behavior; xstd's is a precondition. Either
+way, callers who need `|x|` for *every* input are left without one.
+
+These four return the corresponding unsigned type instead, which can
+represent that value, so they have no precondition at all. They exist mainly
+because the division families' postconditions need them: `div` accepts
+`denom == INT_MIN`, so a check of the form `|rem| < |denom|` written with
+`abs` would trip its own precondition on a call that is perfectly in
+contract. A contract check must not have a narrower domain than the
+operation it verifies.
+
+The negation is done by unsigned wraparound rather than by widening to a
+bigger signed type. Wraparound is well-defined where `-x` on a signed
+minimum is not, and it works uniformly at all four widths - `intmax_t` has
+nothing wider to widen to.
+
+The name keeps the relationship to `abs` visible at the call site, which
+`magnitude` (what these were called while they were an implementation
+detail) did not. Rust names the same operation
+[`unsigned_abs`](https://doc.rust-lang.org/std/primitive.i32.html#method.unsigned_abs)
+for the same reason; C++ has no equivalent, standard or in Boost.Math.
+
 ### `xstd::div_t`/`xstd::ldiv_t`/`xstd::lldiv_t`/`xstd::imaxdiv_t` formatting
 
 Each type's `std::formatter` specialization delegates to

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -42,6 +42,36 @@ namespace xstd {
         return x < 0 ? -x : x;
 }
 
+// The total counterpart of the abs family above: same |x|, but returning the
+// unsigned type, so the one input abs has to exclude - the most negative
+// value, whose magnitude is one past the signed maximum - is in contract
+// here. Negation is done by unsigned wraparound, which is well-defined,
+// rather than by -x on a signed MIN, which is not, or by widening to a
+// bigger signed type, which has none to widen to at the intmax_t end.
+// Same four widths and the same non-template style as abs, and likewise
+// distinct names rather than an overload set: long and intmax_t are the same
+// type on some platforms (e.g. 64-bit Linux) and distinct on others, so
+// overloads could collide there.
+[[nodiscard]] constexpr unsigned uabs(int x) noexcept
+{
+        return x < 0 ? unsigned{} - static_cast<unsigned>(x) : static_cast<unsigned>(x);
+}
+
+[[nodiscard]] constexpr unsigned long ulabs(long x) noexcept
+{
+        return x < 0 ? static_cast<unsigned long>(0) - static_cast<unsigned long>(x) : static_cast<unsigned long>(x);
+}
+
+[[nodiscard]] constexpr unsigned long long ullabs(long long x) noexcept
+{
+        return x < 0 ? static_cast<unsigned long long>(0) - static_cast<unsigned long long>(x) : static_cast<unsigned long long>(x);
+}
+
+[[nodiscard]] constexpr std::uintmax_t uimaxabs(std::intmax_t x) noexcept
+{
+        return x < 0 ? static_cast<std::uintmax_t>(0) - static_cast<std::uintmax_t>(x) : static_cast<std::uintmax_t>(x);
+}
+
 // not part of <cstdlib>, but kept to the same style and the same four
 // widths as the abs family above: plain integral types, no templates.
 [[nodiscard]] constexpr int sign(int x) noexcept
@@ -88,37 +118,6 @@ struct imaxdiv_t
         [[nodiscard]] friend constexpr bool operator==(imaxdiv_t const&, imaxdiv_t const&) noexcept = default;
 };
 
-namespace detail {
-
-// |x| computed via unsigned wraparound (well-defined, unlike -x on a signed
-// MIN) rather than by widening to a bigger signed type: long and intmax_t
-// are the same type on some platforms (e.g. 64-bit Linux), so a same-named
-// overload set for these helpers could collide there; distinct names avoid
-// that regardless of platform, matching how the public family above already
-// uses distinct names (abs/labs/llabs/imaxabs) rather than overloads.
-
-[[nodiscard]] constexpr unsigned magnitude(int x) noexcept
-{
-        return x < 0 ? unsigned{} - static_cast<unsigned>(x) : static_cast<unsigned>(x);
-}
-
-[[nodiscard]] constexpr unsigned long lmagnitude(long x) noexcept
-{
-        return x < 0 ? static_cast<unsigned long>(0) - static_cast<unsigned long>(x) : static_cast<unsigned long>(x);
-}
-
-[[nodiscard]] constexpr unsigned long long llmagnitude(long long x) noexcept
-{
-        return x < 0 ? static_cast<unsigned long long>(0) - static_cast<unsigned long long>(x) : static_cast<unsigned long long>(x);
-}
-
-[[nodiscard]] constexpr std::uintmax_t imaxmagnitude(std::intmax_t x) noexcept
-{
-        return x < 0 ? static_cast<std::uintmax_t>(0) - static_cast<std::uintmax_t>(x) : static_cast<std::uintmax_t>(x);
-}
-
-} // namespace detail
-
 // C++ Standard [expr.mul]/4
 // https://en.wikipedia.org/wiki/Modulo_operation
 // http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf
@@ -129,7 +128,7 @@ namespace detail {
 // overflow) is only possible for div: long long is guaranteed wide enough
 // to hold the product of two ints, but there is no portable type wider than
 // long long/intmax_t to give the same guarantee for the other three, so
-// those rely solely on the sign/magnitude assertions below.
+// those rely solely on the sign and magnitude assertions below.
 // %: C99, C++11, C#, D, F#, Go, Java, Javascript, PHP, Rust, Scala, Swift
 // rem: Ada, Clojure, Erlang, Haskell, Julia, Lisp, Prolog
 // remainder: Ruby, Scheme
@@ -141,7 +140,7 @@ namespace detail {
         auto const qT = numer / denom;
         auto const rT = numer % denom;
         assert(static_cast<long long>(numer) == (static_cast<long long>(denom) * qT) + rT);
-        assert(detail::magnitude(rT) < detail::magnitude(denom));
+        assert(uabs(rT) < uabs(denom));
         assert(sign(rT) == sign(numer) || rT == 0);
         return {.quot = qT, .rem = rT};
 }
@@ -152,7 +151,7 @@ namespace detail {
         assert(!(numer == std::numeric_limits<long>::min() && denom == -1));
         auto const qT = numer / denom;
         auto const rT = numer % denom;
-        assert(detail::lmagnitude(rT) < detail::lmagnitude(denom));
+        assert(ulabs(rT) < ulabs(denom));
         assert(lsign(rT) == lsign(numer) || rT == 0);
         return {.quot = qT, .rem = rT};
 }
@@ -163,7 +162,7 @@ namespace detail {
         assert(!(numer == std::numeric_limits<long long>::min() && denom == -1));
         auto const qT = numer / denom;
         auto const rT = numer % denom;
-        assert(detail::llmagnitude(rT) < detail::llmagnitude(denom));
+        assert(ullabs(rT) < ullabs(denom));
         assert(llsign(rT) == llsign(numer) || rT == 0);
         return {.quot = qT, .rem = rT};
 }
@@ -174,7 +173,7 @@ namespace detail {
         assert(!(numer == std::numeric_limits<std::intmax_t>::min() && denom == -1));
         auto const qT = numer / denom;
         auto const rT = numer % denom;
-        assert(detail::imaxmagnitude(rT) < detail::imaxmagnitude(denom));
+        assert(uimaxabs(rT) < uimaxabs(denom));
         assert(imaxsign(rT) == imaxsign(numer) || rT == 0);
         return {.quot = qT, .rem = rT};
 }
@@ -190,7 +189,7 @@ namespace detail {
         auto const qE = divT.quot - I;
         auto const rE = divT.rem + (I * denom);
         assert(static_cast<long long>(numer) == (static_cast<long long>(denom) * qE) + rE);
-        assert(detail::magnitude(rE) < detail::magnitude(denom));
+        assert(uabs(rE) < uabs(denom));
         assert(sign(rE) >= 0);
         return {.quot = qE, .rem = rE};
 }
@@ -202,7 +201,7 @@ namespace detail {
         auto const I = divT.rem >= 0 ? 0L : (denom > 0 ? 1L : -1L);
         auto const qE = divT.quot - I;
         auto const rE = divT.rem + (I * denom);
-        assert(detail::lmagnitude(rE) < detail::lmagnitude(denom));
+        assert(ulabs(rE) < ulabs(denom));
         assert(lsign(rE) >= 0);
         return {.quot = qE, .rem = rE};
 }
@@ -214,7 +213,7 @@ namespace detail {
         auto const I = divT.rem >= 0 ? 0LL : (denom > 0 ? 1LL : -1LL);
         auto const qE = divT.quot - I;
         auto const rE = divT.rem + (I * denom);
-        assert(detail::llmagnitude(rE) < detail::llmagnitude(denom));
+        assert(ullabs(rE) < ullabs(denom));
         assert(llsign(rE) >= 0);
         return {.quot = qE, .rem = rE};
 }
@@ -226,7 +225,7 @@ namespace detail {
         auto const I = divT.rem >= 0 ? std::intmax_t{0} : (denom > 0 ? std::intmax_t{1} : std::intmax_t{-1});
         auto const qE = divT.quot - I;
         auto const rE = divT.rem + (I * denom);
-        assert(detail::imaxmagnitude(rE) < detail::imaxmagnitude(denom));
+        assert(uimaxabs(rE) < uimaxabs(denom));
         assert(imaxsign(rE) >= 0);
         return {.quot = qE, .rem = rE};
 }
@@ -243,7 +242,7 @@ namespace detail {
         auto const qF = divT.quot - I;
         auto const rF = divT.rem + (I * denom);
         assert(static_cast<long long>(numer) == (static_cast<long long>(denom) * qF) + rF);
-        assert(detail::magnitude(rF) < detail::magnitude(denom));
+        assert(uabs(rF) < uabs(denom));
         assert(rF == 0 || sign(rF) == sign(denom));
         return {.quot = qF, .rem = rF};
 }
@@ -255,7 +254,7 @@ namespace detail {
         auto const I = lsign(divT.rem) == -lsign(denom) ? 1L : 0L;
         auto const qF = divT.quot - I;
         auto const rF = divT.rem + (I * denom);
-        assert(detail::lmagnitude(rF) < detail::lmagnitude(denom));
+        assert(ulabs(rF) < ulabs(denom));
         assert(rF == 0 || lsign(rF) == lsign(denom));
         return {.quot = qF, .rem = rF};
 }
@@ -267,7 +266,7 @@ namespace detail {
         auto const I = llsign(divT.rem) == -llsign(denom) ? 1LL : 0LL;
         auto const qF = divT.quot - I;
         auto const rF = divT.rem + (I * denom);
-        assert(detail::llmagnitude(rF) < detail::llmagnitude(denom));
+        assert(ullabs(rF) < ullabs(denom));
         assert(rF == 0 || llsign(rF) == llsign(denom));
         return {.quot = qF, .rem = rF};
 }
@@ -279,7 +278,7 @@ namespace detail {
         auto const I = imaxsign(divT.rem) == -imaxsign(denom) ? std::intmax_t{1} : std::intmax_t{0};
         auto const qF = divT.quot - I;
         auto const rF = divT.rem + (I * denom);
-        assert(detail::imaxmagnitude(rF) < detail::imaxmagnitude(denom));
+        assert(uimaxabs(rF) < uimaxabs(denom));
         assert(rF == 0 || imaxsign(rF) == imaxsign(denom));
         return {.quot = qF, .rem = rF};
 }

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -3,7 +3,7 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <xstd/cstdlib.hpp>         // /(l{0,2}|imax)(abs|sign|div_t?|magnitude)/, /(euclidean|floored)_(l{0,2}|imax)div/
+#include <xstd/cstdlib.hpp>         // /u?(l{0,2}|imax)(abs|sign|div_t?)/, /(euclidean|floored)_(l{0,2}|imax)div/
 #include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK_EQUAL
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_CHECK_EQUAL, BOOST_CHECK_EQUAL_COLLECTIONS
 #include <algorithm>                // transform
@@ -171,27 +171,27 @@ BOOST_AUTO_TEST_CASE(ExactDivisions)
         XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-6, -3), (xstd::div_t{+2, 0}));
 }
 
-// detail::magnitude/lmagnitude/llmagnitude/imaxmagnitude are only exercised
-// transitively above, through the div families' assert() guards; check
-// their own MIN-boundary wraparound directly and at compile time, since
-// that's the one case a widening-based |x| could not have handled.
-BOOST_AUTO_TEST_CASE(Magnitude)
+// The div families exercise uabs/ulabs/ullabs/uimaxabs transitively through
+// their assert() guards; check the MIN-boundary wraparound directly and at
+// compile time, since that is both what distinguishes these from abs and the
+// one case a widening-based |x| could not have handled.
+BOOST_AUTO_TEST_CASE(UnsignedAbs)
 {
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::detail::magnitude(-2), 2u);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::detail::magnitude(+2), 2u);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::detail::magnitude(0), 0u);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(-2), 2u);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(+2), 2u);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(0), 0u);
 
         using limits = std::numeric_limits<int>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::detail::magnitude(limits::min()), static_cast<unsigned>(limits::max()) + 1u);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(limits::min()), static_cast<unsigned>(limits::max()) + 1u);
 
         using llimits = std::numeric_limits<long>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::detail::lmagnitude(llimits::min()), static_cast<unsigned long>(llimits::max()) + 1ul);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::ulabs(llimits::min()), static_cast<unsigned long>(llimits::max()) + 1ul);
 
         using lllimits = std::numeric_limits<long long>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::detail::llmagnitude(lllimits::min()), static_cast<unsigned long long>(lllimits::max()) + 1ull);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::ullabs(lllimits::min()), static_cast<unsigned long long>(lllimits::max()) + 1ull);
 
         using imaxlimits = std::numeric_limits<std::intmax_t>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::detail::imaxmagnitude(imaxlimits::min()), static_cast<std::uintmax_t>(imaxlimits::max()) + std::uintmax_t{1});
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uimaxabs(imaxlimits::min()), static_cast<std::uintmax_t>(imaxlimits::max()) + std::uintmax_t{1});
 }
 
 BOOST_AUTO_TEST_CASE(BoundaryDivisions)


### PR DESCRIPTION
### Motivation

The four `magnitude` helpers lived in `detail::` but were never really private. The test suite reached in and checked them by name, at all four widths, at their `MIN` boundary:

```cpp
BOOST_AUTO_TEST_CASE(Magnitude)
{
        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::detail::magnitude(limits::min()), ...);
        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::detail::lmagnitude(llimits::min()), ...);
        ...
}
```

with a comment noting that wraparound is "the one case a widening-based `|x|` could not have handled". That is a facility being tested for its own sake, not incidental coverage of an implementation detail.

It also fills a real gap. `abs` cannot be total: `|x|` for a signed minimum is one past that type's maximum, so there is no signed result to return, and the standard's answer is undefined behavior. Callers who need `|x|` for *every* input have nothing to reach for. Rust standardises exactly this as [`unsigned_abs`](https://doc.rust-lang.org/std/primitive.i32.html#method.unsigned_abs); C++ has no equivalent, in the standard or in Boost.Math — whose `sign.hpp` offers only `signbit`, `sign`, `copysign` and `changesign`.

### Description

- Move the four helpers out of `detail::` into `xstd::`, renamed **`uabs`/`ulabs`/`ullabs`/`uimaxabs`**. The implementations are unchanged.
- `detail::` held nothing else, so the namespace goes with them.
- The `div` families' assertions now call the public names. Behaviour is unchanged, and `denom == INT_MIN` stays in contract — which is precisely why those checks cannot be written with `abs`: a check must not have a narrower domain than the operation it verifies.
- Document the family in README's table, with a short example contrasting it with `abs` at `INT_MIN`, and record the rationale in `doc/design.md`.

On the name: `magnitude` described the value but hid the relationship that justifies it. These are `abs`, made total by returning the unsigned type, and the `u`-prefixed names sit directly beside `abs`/`labs`/`llabs`/`imaxabs` and say so at the call site — the same reasoning behind Rust's choice of `unsigned_abs` over a standalone noun. The distinct-names-rather-than-overloads decision is unchanged and still documented: `long` and `intmax_t` are the same type on some platforms and distinct on others.

### Testing

- All four widths verified as `static_assert`s at their `MIN` boundary, plus the negative, positive and zero cases, and the README example verbatim — under both GCC and Clang, with the GNU warning set the test target uses (`-Wall -Wextra -Wpedantic -Wconversion -Wshadow -Wsign-conversion -pedantic-errors`): no diagnostics.
- `div(5, INT_MIN)` still verified as a `static_assert`, confirming the promoted names keep that call in contract.
- `clang-format --dry-run --Werror` on both changed sources: clean.
- `clang-tidy` with the repository's unmodified `.clang-tidy`: clean, exit 0.

One limitation worth stating: local GCC is 13, which lacks the tuple `formatter` (P2286R8) that `<xstd/cstdlib.hpp>` needs, so I could not compile the header end-to-end here — the checks above ran against the portion up to the division families, which covers everything this PR touches. CI compiles the whole header on every leg.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajh3U4muFsE9u9JBbggrR1)_