### PR TITLE
Retry add-apt-repository's Launchpad API call

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -51,7 +51,13 @@ jobs:
       # enough. Matches clang.yml's own fix for the same underlying problem.
       - name: Install a <format>-capable libstdc++
         run: |
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          # Retried for the reason given in gcc.yml: the ppa: shorthand goes
+          # through Launchpad's web API, which Acquire::Retries does not cover.
+          for i in 1 2 3; do
+            if sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; then break; fi
+            if [ "$i" -eq 3 ]; then exit 1; fi
+            sleep $((i * 5))
+          done
           sudo apt-get update
           sudo apt-get install -y g++-15
 

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -96,7 +96,13 @@ jobs:
       - name: Install libstdc++ ${{ matrix.gcc_version }}
         if: "!matrix.gcc_trunk"
         run: |
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          # Retried for the reason given in gcc.yml: the ppa: shorthand goes
+          # through Launchpad's web API, which Acquire::Retries does not cover.
+          for i in 1 2 3; do
+            if sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; then break; fi
+            if [ "$i" -eq 3 ]; then exit 1; fi
+            sleep $((i * 5))
+          done
           sudo apt-get update
           sudo apt-get install -y g++-${{ matrix.gcc_version }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,13 @@ jobs:
       # gcc.yml/sanitizers.yml's own fix for the same underlying problem.
       - name: Install a <format>-capable GCC
         run: |
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          # Retried for the reason given in gcc.yml: the ppa: shorthand goes
+          # through Launchpad's web API, which Acquire::Retries does not cover.
+          for i in 1 2 3; do
+            if sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; then break; fi
+            if [ "$i" -eq 3 ]; then exit 1; fi
+            sleep $((i * 5))
+          done
           sudo apt-get update
           sudo apt-get install -y g++-15
 

--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -37,7 +37,13 @@ jobs:
 
       - name: Install GCC 15
         run: |
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          # Retried for the reason given in gcc.yml: the ppa: shorthand goes
+          # through Launchpad's web API, which Acquire::Retries does not cover.
+          for i in 1 2 3; do
+            if sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; then break; fi
+            if [ "$i" -eq 3 ]; then exit 1; fi
+            sleep $((i * 5))
+          done
           sudo apt-get update
           sudo apt-get install -y g++-15
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,13 @@ jobs:
 
       - name: Install GCC 15 and gcovr
         run: |
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          # Retried for the reason given in gcc.yml: the ppa: shorthand goes
+          # through Launchpad's web API, which Acquire::Retries does not cover.
+          for i in 1 2 3; do
+            if sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; then break; fi
+            if [ "$i" -eq 3 ]; then exit 1; fi
+            sleep $((i * 5))
+          done
           sudo apt-get update
           sudo apt-get install -y g++-15 python3-pip
           python3 -m pip install --user gcovr

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -58,7 +58,16 @@ jobs:
       - name: Install GCC ${{ matrix.version }} (stable)
         if: "!matrix.trunk"
         run: |
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          # add-apt-repository resolves a ppa: shorthand through Launchpad's
+          # web API via launchpadlib, before apt is involved at all, so the
+          # Acquire::Retries setting above does not cover it: that governs
+          # apt's own downloads. A truncated response here (IncompleteRead)
+          # fails the step outright, so retry the call itself.
+          for i in 1 2 3; do
+            if sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; then break; fi
+            if [ "$i" -eq 3 ]; then exit 1; fi
+            sleep $((i * 5))
+          done
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.cxx }}
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -47,7 +47,13 @@ jobs:
 
       - name: Install GCC 15
         run: |
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          # Retried for the reason given in gcc.yml: the ppa: shorthand goes
+          # through Launchpad's web API, which Acquire::Retries does not cover.
+          for i in 1 2 3; do
+            if sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; then break; fi
+            if [ "$i" -eq 3 ]; then exit 1; fi
+            sleep $((i * 5))
+          done
           sudo apt-get update
           sudo apt-get install -y g++-15
 


### PR DESCRIPTION
### Motivation

`Acquire::Retries` governs apt's own downloads. The `ppa:` shorthand is resolved **before apt is involved at all**: `add-apt-repository` asks Launchpad's web API through `launchpadlib`, and that call has no retry. A truncated response there failed `Clang 22` on a six-line documentation PR (#102):

```
File ".../softwareproperties/ppa.py", line 111, in lp
File ".../lazr/restfulclient/_browser.py", line 502, in get_wadl_application
http.client.IncompleteRead: IncompleteRead(118212 bytes read)
```

That is the third distinct Launchpad failure mode this CI has hit — after 503s on `.deb` fetches and a sustained mirror brownout — and the first that the existing hardening does not cover. It needed a manual re-run.

### Description

Wrap the seven `ppa:` call sites in a bounded retry (`gcc.yml`, `clang.yml`, `clang-tidy.yml`, `codeql.yml`, `consumption.yml`, `coverage.yml`, `sanitizers.yml`):

```sh
for i in 1 2 3; do
  if sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; then break; fi
  if [ "$i" -eq 3 ]; then exit 1; fi
  sleep $((i * 5))
done
```

The `if` form is deliberate. The more idiomatic `cmd && break` would make the loop body an AND list whose failure status trips `set -e` — which GitHub uses for `run:` blocks — aborting the step on the *first* attempt and defeating the retry entirely. `if` conditions are exempt from `set -e`, so the loop actually loops.

The two literal `deb …` calls in `clang.yml` and `clang-libc++.yml` are left alone: they name the suite directly and never touch the API, so apt's own retries already cover them.

Full rationale in `gcc.yml`, with a one-line cross-reference in the other six, following the existing convention in `clang-libc++.yml`.

The alternative — replacing the shorthand with a literal deb line plus an explicitly managed signing key — would eliminate the API dependency rather than retry it, at the cost of pinning a key fingerprint in the workflows. Not worth it for a transient that three attempts absorb.

### Testing

- All sixteen workflow files still parse.
- Each of the seven patched `run:` blocks extracted and checked with `bash -n`: valid syntax.
- The retry semantics verified directly under `set -e`, which is the subtle part:
  - a command failing twice then succeeding → loop completes, step continues (confirming `set -e` does not abort on the intermediate failures)
  - a command failing all three times → step exits 1 rather than falling through silently
- CI on this PR exercises all seven touched workflows.

The same gap exists in [rhalbersma/tabula](https://github.com/rhalbersma/tabula), which carries the same seven call sites and the same `Acquire::Retries` drop-in; an identical change is up there too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajh3U4muFsE9u9JBbggrR1)_