### PR TITLE
Spell uabs's zero the same way as its three siblings

### DIFF
--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -54,7 +54,7 @@ namespace xstd {
 // overloads could collide there.
 [[nodiscard]] constexpr unsigned uabs(int x) noexcept
 {
-        return x < 0 ? unsigned{} - static_cast<unsigned>(x) : static_cast<unsigned>(x);
+        return x < 0 ? static_cast<unsigned>(0) - static_cast<unsigned>(x) : static_cast<unsigned>(x);
 }
 
 [[nodiscard]] constexpr unsigned long ulabs(long x) noexcept


### PR DESCRIPTION
`uabs`, `ulabs`, `ullabs` and `uimaxabs` are the same expression at four widths, but `uabs` alone wrote its zero as `unsigned{}` while the other three used `static_cast<T>(0)`. That inconsistency was carried over verbatim from `detail::magnitude` when the family was promoted to the public API in #103.

```diff
-        return x < 0 ? unsigned{} - static_cast<unsigned>(x) : static_cast<unsigned>(x);
+        return x < 0 ? static_cast<unsigned>(0) - static_cast<unsigned>(x) : static_cast<unsigned>(x);
```

## Why the cast rather than a literal suffix

`0u`/`0ul`/`0ull` would cover three of the four widths, but `std::uintmax_t` has no literal suffix. Its only standard spelling is `UINTMAX_C(0)` from `<cstdint>` — a macro whose expansion is implementation-defined (`0UL` on LP64, `0ULL` on Windows), and it would be the only macro in the header.

Falling back to `0ull` in `uimaxabs` is value-correct but makes the expression's type stop matching the return type on exactly one class of platform: where `uintmax_t` is `unsigned long`, `0ull - static_cast<std::uintmax_t>(x)` promotes to `unsigned long long` under the usual arithmetic conversions and converts back on return; on Windows it doesn't promote at all. That is the same platform-dependent asymmetry the `imax`-prefixed *names* already exist to avoid (see `doc/design.md`). Naming the typedef in a cast is correct by construction regardless of what it aliases.

So the choice is one spelling that works at all four widths, or suffixes for three and something else for the fourth. The uniform spelling also puts the same type name on both sides of the `-`, making it locally visible that no conversion happens.

Two alternatives considered and rejected:

- **Bare `0`** — correct, but leans on an implicit signed-to-unsigned conversion in a function whose entire point is that the wraparound is deliberate.
- **`-static_cast<unsigned>(x)`** — shortest correct spelling, since unary minus on an unsigned operand is already well-defined wraparound. Rejected because MSVC's C4146 ("unary minus operator applied to unsigned type, result still unsigned") is a level-2 warning and the test suite builds at `/W4`; that diagnostic exists to catch the accident this code commits on purpose.

## Verification

- `static_assert`s pass at all four widths' `MIN` under both GCC and Clang with the project's full warning set.
- Generated assembly is byte-identical to the previous spelling, so behaviour and codegen are unchanged.
- `clang-format --dry-run --Werror` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ajh3U4muFsE9u9JBbggrR1)_