### PR TITLE
Collapse the abs/uabs/sign/div families into one template each

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -82,7 +82,7 @@ jobs:
       # leaves NDEBUG undefined, which is what matters here, but it does so
       # by accident and is one preset change away from silently becoming
       # Release. CMake's Release adds -DNDEBUG, which rewrites every
-      # assert(...) to ((void)0) before it reaches the AST - 16 of them
+      # assert(...) to ((void)0) before it reaches the AST - 14 of them
       # across cstdlib.hpp and utility.hpp - which would disable
       # bugprone-assert-side-effect outright and strip the assertions
       # clang-analyzer-* uses to prune infeasible paths. Matches codeql.yml.

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -82,7 +82,7 @@ jobs:
       # leaves NDEBUG undefined, which is what matters here, but it does so
       # by accident and is one preset change away from silently becoming
       # Release. CMake's Release adds -DNDEBUG, which rewrites every
-      # assert(...) to ((void)0) before it reaches the AST - 49 of them
+      # assert(...) to ((void)0) before it reaches the AST - 16 of them
       # across cstdlib.hpp and utility.hpp - which would disable
       # bugprone-assert-side-effect outright and strip the assertions
       # clang-analyzer-* uses to prune infeasible paths. Matches codeql.yml.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,7 +81,7 @@ jobs:
       # leaves NDEBUG undefined, which is what matters here, but it does so
       # by accident and is one preset change away from silently becoming
       # Release. CMake's Release adds -DNDEBUG, which rewrites every
-      # assert(...) to ((void)0) before it reaches the AST - 49 of them
+      # assert(...) to ((void)0) before it reaches the AST - 16 of them
       # across cstdlib.hpp and utility.hpp - and CodeQL's C/C++ extractor
       # runs alongside the compiler front-end, so it gains nothing from the
       # optimization level while losing all of that code. Matches

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,7 +81,7 @@ jobs:
       # leaves NDEBUG undefined, which is what matters here, but it does so
       # by accident and is one preset change away from silently becoming
       # Release. CMake's Release adds -DNDEBUG, which rewrites every
-      # assert(...) to ((void)0) before it reaches the AST - 16 of them
+      # assert(...) to ((void)0) before it reaches the AST - 14 of them
       # across cstdlib.hpp and utility.hpp - and CodeQL's C/C++ extractor
       # runs alongside the compiler front-end, so it gains nothing from the
       # optimization level while losing all of that code. Matches

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ xstd is a header-only C++23 library for small standard-library extensions that c
 | Header                   | Additions          | Description | Reference |
 | :-----                   | :--------          | :---------- | :-------- |
 | `<xstd/array.hpp>`       | `array_from_types` | Create an `array` from a type list | none |
-| `<xstd/cstdlib.hpp>`     | `sign`/`lsign`/`llsign`/`imaxsign` <br> `abs`/`labs`/`llabs`/`imaxabs` <br> `uabs`/`ulabs`/`ullabs`/`uimaxabs` <br> `div`/`ldiv`/`lldiv`/`imaxdiv` <br> `div_t`/`ldiv_t`/`lldiv_t`/`imaxdiv_t` <br> `euclidean_div` and siblings <br> `floored_div` and siblings | `constexpr` support <br> `constexpr` support <br> Total `\|x\|`, returning the unsigned type <br> `constexpr` support <br> `std::format` support, defaulted equality comparison <br> Euclidean division, at all 4 widths <br> Floored division, at all 4 widths | [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Rust `unsigned_abs`](https://doc.rust-lang.org/std/primitive.i32.html#method.unsigned_abs) (no C++ equivalent) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p2286r8](https://wg21.link/p2286r8) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) |
+| `<xstd/cstdlib.hpp>`     | `sign` <br> `abs` <br> `uabs` <br> `div` <br> `div_t` <br> `euclidean_div` <br> `floored_div` | `constexpr`, any signed integral type <br> `constexpr`, any signed integral type <br> Total `\|x\|`, returning the unsigned type <br> `constexpr`, any signed integral type <br> `std::format` support, defaulted equality comparison <br> Euclidean division <br> Floored division | [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Rust `unsigned_abs`](https://doc.rust-lang.org/std/primitive.i32.html#method.unsigned_abs) (no C++ equivalent) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [p2286r8](https://wg21.link/p2286r8) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) |
 | `<xstd/type_traits.hpp>` | `is_specialization_of` <br> `is_integral_constant` <br> `tagged_empty` <br> `optional_type` | Is a type a class template specialization? <br> Is a type an `integral_constant`? <br> A tagged empty type <br> An optional type | [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) <br> none <br> none <br> none |
 | `<xstd/utility.hpp>`     | `to_underlying` <br> `aligned_size` | `std::integral_constant` overload <br> Round a size up to a multiple of an alignment | none <br> none |
 
@@ -88,10 +88,11 @@ static_assert(xstd::aligned_size(100, 64) == 128);
 
 ### Absolute value without a precondition
 
-`xstd::abs` mirrors `<cstdlib>`: it returns the signed type, so the most negative value is outside its contract. `xstd::uabs` returns the unsigned type, which can represent that magnitude, and so has no precondition:
+`xstd::abs` returns the signed type, like `<cstdlib>`'s, so the most negative value is outside its contract. `xstd::uabs` returns the unsigned type, which can represent that magnitude, and so has no precondition:
 
 ```cpp
 #include <climits>
+#include <cstdint>
 #include <xstd/cstdlib.hpp>
 
 static_assert(xstd::abs(-2) == 2);
@@ -99,9 +100,11 @@ static_assert(xstd::uabs(-2) == 2u);
 
 // |INT_MIN| is one past INT_MAX, so only the unsigned form can return it
 static_assert(xstd::uabs(INT_MIN) == static_cast<unsigned>(INT_MAX) + 1u);
-```
 
-`ulabs`, `ullabs`, and `uimaxabs` cover `long`, `long long`, and `intmax_t`, following the same naming as `labs`/`llabs`/`imaxabs`.
+// one template per operation, so every signed integral width is covered,
+// including the two the labs/llabs/imaxabs naming has no name for
+static_assert(xstd::uabs(std::int8_t{-128}) == std::uint8_t{128});
+```
 
 ### Division helpers
 
@@ -122,13 +125,21 @@ static_assert(floored.rem == 1);
 auto const text = std::format("{}", floored); // "(-3, 1)"
 ```
 
-`xstd::div`, `xstd::euclidean_div`, and `xstd::floored_div` require a nonzero denominator. Like built-in signed integer division, `INT_MIN / -1` is outside their contract for `int` inputs. `xstd::div` follows C++'s truncated division semantics, `xstd::euclidean_div` always returns a nonnegative remainder, and `xstd::floored_div` returns a remainder with the divisor's sign unless the remainder is zero. Each has 3 wider siblings following `<cstdlib>`/`<cinttypes>`'s own naming: `ldiv`/`euclidean_ldiv`/`floored_ldiv` for `long`, `lldiv`/`euclidean_lldiv`/`floored_lldiv` for `long long`, and `imaxdiv`/`euclidean_imaxdiv`/`floored_imaxdiv` for `intmax_t`, returning `xstd::ldiv_t`, `xstd::lldiv_t`, and `xstd::imaxdiv_t` respectively.
+`xstd::div`, `xstd::euclidean_div`, and `xstd::floored_div` require a nonzero denominator. Like built-in signed integer division, `MIN / -1` is outside their contract. `xstd::div` follows C++'s truncated division semantics, `xstd::euclidean_div` always returns a nonnegative remainder, and `xstd::floored_div` returns a remainder with the divisor's sign unless the remainder is zero. Each returns `xstd::div_t<T>` for its argument type `T`; class template argument deduction means the result can still be written `xstd::div_t{quot, rem}`.
 
-Formatting any of these 4 `div_t`-like types requires C++23 standard-library support for formatting tuple-like values. This is covered by the continuously tested compiler and standard-library versions below. Prefer `std::format`/`std::print` over the types' `operator<<`, which exists only for test-framework diagnostics.
+Formatting `xstd::div_t` requires C++23 standard-library support for formatting tuple-like values. This is covered by the continuously tested compiler and standard-library versions below. Prefer `std::format`/`std::print` over its `operator<<`, which exists only for test-framework diagnostics.
 
-`xstd::abs`, `xstd::labs`, `xstd::llabs`, and `xstd::imaxabs` mirror `<cstdlib>`'s own `abs`/`labs`/`llabs` and `<cinttypes>`'s `imaxabs`: signed integral arguments only, no unsigned support. As with the built-in unary minus, the most negative value of each parameter type is outside its contract (guarded by an `assert`), just like `INT_MIN / -1` is for the division helpers. `xstd::sign`, `xstd::lsign`, `xstd::llsign`, and `xstd::imaxsign` aren't part of `<cstdlib>`, but follow the same 4-width naming, each always returning a plain `int`.
+### Width and constraints
 
-See [doc/design.md](doc/design.md) for the rationale behind these APIs' shapes (why non-template, why `imax`-prefixed names, etc.).
+Every function in `<xstd/cstdlib.hpp>` is a single function template constrained to `std::signed_integral`, rather than the four fixed-width overloads (`abs`/`labs`/`llabs`/`imaxabs` and friends) `<cstdlib>` and `<cinttypes>` declare. Three consequences at the call site:
+
+- **Every signed integral width is covered**, including `std::int8_t` and `std::int16_t`, which the `<cstdlib>` naming has no name for. 128-bit integers are the exception: `__int128` doesn't satisfy `std::integral` in the strictly conforming dialect this library targets, so it is not supported.
+- **The result type is the argument type, not the promoted type.** `xstd::abs` of an `std::int16_t` is an `std::int16_t`, and its precondition is `std::int16_t`'s — the most negative value of the *argument* type is outside its contract (guarded by an `assert`), just like `MIN / -1` is for the division helpers. Callers who want the old promoting behavior write `xstd::abs(+x)` or `xstd::abs<int>(x)`.
+- **Two-argument templates deduce one `T` from both arguments**, so a mixed-width call like `xstd::div(8, 3L)` is a deduction failure rather than a silent conversion. Spell the intent as `xstd::div<long>(8, 3L)`.
+
+`xstd::sign` isn't part of `<cstdlib>`, and always returns a plain `int` whatever its argument's width.
+
+See [doc/design.md](doc/design.md) for the rationale behind these APIs' shapes (why one template rather than four overloads, why 128-bit integers are out).
 
 ### Type traits
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -139,36 +139,44 @@ for the same reason; C++ has no equivalent, standard or in Boost.Math.
 
 ### The division contracts' back-multiplication check
 
-The strongest self-check the division functions can make is
-`numer == denom * q + r`, and it is only meaningful evaluated in a type wide
-enough that the multiplication itself cannot overflow. As four separate
-overloads, only `div` made it: `long long` holds the product of *any* two
-`int`s, but there is no portable type wider than `long long`/`intmax_t` to
-give `ldiv`/`lldiv`/`imaxdiv` the same guarantee, so those three carried a
-weaker contract with no way to say so once.
+`numer == denom * q + r` is the strongest self-check a division function can
+make, but it is only worth making once. For truncated division it is a real
+check: it holds the built-in `/` and `%` against each other, and it needs no
+widening to evaluate, because `denom * qT` is exactly `numer - rT` and `rT`
+carries `numer`'s sign, so the product lies between `0` and `numer` inclusive
+and is representable wherever `numer` is.
 
-"Any two `int`s" is the wrong bound, though. The operands are not arbitrary
-values of `T`; `q` is `numer` divided by `denom`, which pins the product much
-more tightly - and pins it differently for each convention:
+For the two adjusted conventions it is a tautology. Both compute
+`q' = qT - I` and `r' = rT + I * denom`, so
 
-- **Truncated division needs no widening at all.** `denom * qT` is exactly
-  `numer - rT`, and `rT` carries `numer`'s sign, so the product lies between
-  `0` and `numer` inclusive and is representable wherever `numer` is. `div`
-  asserts the identity in `T` itself, unconditionally - which finally gives
-  the check at `intmax_t` width, where neither the old `imaxdiv` nor a
-  `sizeof`-gated template would have had it.
-- **The adjusted quotients do need it.** `euclidean_div` and `floored_div`
-  move the remainder across zero, so `denom * q = numer - r` can land one unit
-  of `|denom|` outside `T`: for `int32_t`, `numer == INT32_MIN` with
-  `denom == 3` gives `denom * qE == INT32_MIN - 1`. An exhaustive sweep of
-  every in-contract `int8_t` pair finds 5698 such products for Euclidean and
-  5825 for floored, against zero for truncated. The excess is bounded by
-  `|numer| + |denom| < 2^N`, so one extra bit suffices and any wider signed
-  type will do.
+    denom * q' + r' = denom * (qT - I) + rT + I * denom = denom * qT + rT
 
-The gate `sizeof(T) < sizeof(intmax_t)` therefore applies only to the two
-adjusted conventions, and only they fall back to the sign and magnitude
-assertions at the widest width.
+which is `numer` by the check `div` has already made. Asserting it again in
+`euclidean_div` and `floored_div` could only fire where `div`'s own assertion
+had already fired - and, because the adjusted product *can* exceed `T`, doing
+so would have required carrying an `intmax_t` widening and a `sizeof`-based
+gate purely to restate something already known. Those two assertions, and the
+machinery they needed, are gone. What remains for each convention is what
+actually constrains it: the magnitude bound `|r| < |denom|` and its own sign
+rule.
+
+### Why `euclidean_div` adds or subtracts `denom` instead of scaling it
+
+Dropping the identity assertion removes the only thing that would have
+tripped over `I * denom`, which is worth spelling out because that expression
+was unsound on its own terms. `euclidean_div` selects `I == -1` when the
+truncated remainder is negative and `denom` is negative, and `denom == MIN` is
+in contract - so `I * denom` forms `-MIN`, which is not representable. That is
+undefined behavior for `int` and wider; below `int`, integer promotion happens
+to evaluate it in `int` and hide it.
+
+The adjustment is therefore spelled as an addition or a subtraction of `denom`
+chosen by its sign, which never forms `-denom`:
+
+    qE = denom > 0 ? qT - 1 : qT + 1
+    rE = denom > 0 ? rT + denom : rT - denom
+
+`floored_div` needs no such care: it only ever scales `denom` by `0` or `1`.
 
 ### `xstd::div_t` formatting
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -11,7 +11,7 @@ it does.
 Three themes run across the otherwise unrelated headers:
 
 - **`constexpr` all the things.** Every function xstd adds - the division
-  family, `abs`/`sign` and siblings, `array_from_types`, `to_underlying` -
+  family, `abs`/`uabs`/`sign`, `array_from_types`, `to_underlying` -
   is `constexpr`, including the ones that don't strictly need to be for
   their primary use case. A library whose whole point is "make small,
   general-purpose facilities available early" is of limited use if it
@@ -37,73 +37,148 @@ Three themes run across the otherwise unrelated headers:
   remainder, floored division's divisor-signed remainder), and picking
   the wrong one silently for negative operands is a classic source of
   off-by-one bugs. `xstd::div`/`xstd::euclidean_div`/`xstd::floored_div`
-  give each convention its own named function, at all 4 integer widths,
-  so the choice is visible at the call site instead of being buried in
-  which arithmetic operator happened to be used.
+  give each convention its own named function, at every signed integral
+  width, so the choice is visible at the call site instead of being buried
+  in which arithmetic operator happened to be used.
 
 ## API design
 
-### `xstd::abs`/`xstd::labs`/`xstd::llabs`/`xstd::imaxabs`, `xstd::sign`/`xstd::lsign`/`xstd::llsign`/`xstd::imaxsign`
+### One `std::signed_integral` template per operation, not four overloads
 
-Both families are plain, non-template overloads at 4 fixed widths (`int`,
-`long`, `long long`, `intmax_t`), mirroring how `<cstdlib>` itself declares
-`abs`/`labs`/`llabs` and `<cinttypes>` declares `imaxabs`: signed integral
-arguments only, no unsigned support, no generic template. `xstd::sign` and
-friends aren't part of `<cstdlib>`, but were deliberately given the same
-narrow, non-template style rather than being written as a single function
-template over any type - the way `boost::math::sign` is. A single template
-would accept more inputs, but `<cstdlib>`-style non-template overloads keep
-overload resolution and error messages simple, and make it obvious this is
-a small, closed set of widths rather than an extensible facility.
+`abs`, `uabs`, `sign`, `div`, `euclidean_div`, `floored_div` and `div_t` are
+each a single entity constrained to `std::signed_integral`. They started out
+as four fixed-width non-template overloads apiece (`abs`/`labs`/`llabs`/
+`imaxabs` and so on), mirroring how `<cstdlib>` itself declares `abs`/`labs`/
+`llabs` and `<cinttypes>` declares `imaxabs`. That mirroring bought
+`<cstdlib>` familiarity at a price that grew with every operation added:
+twenty-odd near-identical functions, each a copy of the same three lines, and
+a naming scheme with no name at all for the two narrowest signed widths.
 
-`intmax_t` and `long` are the same type on some platforms (e.g. 64-bit
-Linux) and distinct types on others (e.g. Windows). Naming the `intmax_t`
-overloads as unqualified `long`/`intmax_t` overloads of a single function
-name would risk a platform-dependent redeclaration/overload collision;
-the `imax`-prefixed names sidestep that regardless of platform, matching
-how the public family already uses distinct names (`abs`/`labs`/`llabs`/
-`imaxabs`) rather than an overload set.
+The templates cost none of that and cover more. The exact-width types come
+for free - `int8_t`/`int16_t`/`int32_t`/`int64_t` are aliases of `signed
+char`/`short`/`int`/`long`/`long long`, so a template over
+`std::signed_integral` instantiates for each of them, whichever built-in type
+each one happens to name on a given platform. Three follow-on effects were
+weighed and accepted:
 
-### `xstd::uabs`/`xstd::ulabs`/`xstd::ullabs`/`xstd::uimaxabs`
+- **The result type is now the argument type, not the promoted type.** A call
+  to the old non-template `abs(int)` with an `int16_t` argument promoted to
+  `int`, so it returned `int` and, incidentally, was in contract even for
+  `INT16_MIN`. The template returns `int16_t` and takes `int16_t`'s
+  precondition. That is the more defensible contract - the promoting one was
+  an artifact of there being no narrow overload to call - and `abs(+x)`
+  recovers the old behavior explicitly.
+- **Mixed-width calls no longer compile.** `div(T, T)` deduces one `T` from
+  both arguments, so `div(8, 3L)` is a deduction failure where the old
+  `ldiv(long, long)` would have silently converted. An explicit `div<long>`
+  says which width the division happens at, which is the thing that was
+  ambiguous.
+- **The `imax`-prefixed names are no longer needed.** They existed because
+  `intmax_t` and `long` are the same type on some platforms (e.g. 64-bit
+  Linux) and distinct on others (e.g. Windows), so a single overload set
+  spanning both risked a platform-dependent redeclaration collision. One
+  template has no overload set to collide with.
+
+`xstd::sign` isn't part of `<cstdlib>` at all, and is now shaped like
+`boost::math::sign`: one template over the argument type, returning a plain
+`int` at every width, because a sign is a three-valued quantity rather than a
+number in the argument's range.
+
+### Why 128-bit integers are not covered
+
+`__int128` is the obvious next width, and the one the template design would
+otherwise extend to for free. It is excluded for reasons that are all
+external to xstd:
+
+- `std::integral<__int128>` is `false` on libstdc++ outside GNU dialect mode,
+  and the project compiles in the strictly conforming dialect
+  (`CMAKE_CXX_EXTENSIONS OFF`) on purpose. libc++ answers differently, so
+  even the concept check isn't portable.
+- `std::make_unsigned_t<__int128>` is a hard error rather than a substitution
+  failure on libstdc++ in that same mode, so `uabs`'s return type couldn't be
+  spelled with it.
+- GCC's `-pedantic-errors`, which the test targets enable, rejects naming
+  `__int128` at all.
+- MSVC has no 128-bit integer type to cover in the first place.
+
+Supporting it would mean an xstd-local `signed_integral` concept, an
+xstd-local `make_unsigned`, and a test translation unit exempted from the
+project's own conformance flags - three carve-outs from the strict-conformance
+policy in exchange for one width. Should any of those constraints lift, the
+change is a one-line swap of the constraint, which is exactly the property
+the four-overload design did not have: there it would have been a fifth copy
+of every function.
+
+### `xstd::uabs`
 
 `abs` cannot be total: `|x|` for the most negative value of a signed type is
 one past that type's maximum, so there is no signed result to return. The
 standard's answer is undefined behavior; xstd's is a precondition. Either
 way, callers who need `|x|` for *every* input are left without one.
 
-These four return the corresponding unsigned type instead, which can
-represent that value, so they have no precondition at all. They exist mainly
-because the division families' postconditions need them: `div` accepts
-`denom == INT_MIN`, so a check of the form `|rem| < |denom|` written with
-`abs` would trip its own precondition on a call that is perfectly in
-contract. A contract check must not have a narrower domain than the
-operation it verifies.
+`uabs` returns the corresponding unsigned type instead, which can represent
+that value, so it has no precondition at all. It exists mainly because the
+division family's postconditions need it: `div` accepts `denom == MIN`, so a
+check of the form `|rem| < |denom|` written with `abs` would trip its own
+precondition on a call that is perfectly in contract. A contract check must
+not have a narrower domain than the operation it verifies.
 
 The negation is done by unsigned wraparound rather than by widening to a
 bigger signed type. Wraparound is well-defined where `-x` on a signed
-minimum is not, and it works uniformly at all four widths - `intmax_t` has
-nothing wider to widen to.
+minimum is not, and it works uniformly at every width - the widest signed
+type has nothing to widen to. For types narrower than `int` the subtraction
+is evaluated in `int` after promotion and is negative; converting that back
+to the unsigned result type reduces it mod 2^N, which is the same value the
+wider types get directly.
 
 The name keeps the relationship to `abs` visible at the call site, which
-`magnitude` (what these were called while they were an implementation
-detail) did not. Rust names the same operation
+`magnitude` (what this was called while it was an implementation detail) did
+not. Rust names the same operation
 [`unsigned_abs`](https://doc.rust-lang.org/std/primitive.i32.html#method.unsigned_abs)
 for the same reason; C++ has no equivalent, standard or in Boost.Math.
 
-### `xstd::div_t`/`xstd::ldiv_t`/`xstd::lldiv_t`/`xstd::imaxdiv_t` formatting
+### The division contracts' back-multiplication check
 
-Each type's `std::formatter` specialization delegates to
+The strongest self-check the division functions can make is
+`numer == denom * q + r`, and it is only meaningful evaluated in a type wide
+enough that the multiplication itself cannot overflow. As four separate
+overloads, only `div` could make it - `long long` is guaranteed wide enough to
+hold the product of two `int`s, but there was no portable type wider than
+`long long`/`intmax_t` to give `ldiv`/`lldiv`/`imaxdiv` the same guarantee, so
+those three carried a weaker contract with no way to say so once.
+
+The template states the condition instead of the conclusion:
+`sizeof(T) < sizeof(intmax_t)` decides, per instantiation, whether there is a
+wider type to check in. Widths that have one now get the check whether or not
+they had a name before (`int8_t`, `int16_t`, `int32_t`), and the widest ones
+fall back to the sign and magnitude assertions exactly as they used to.
+
+### `xstd::div_t` formatting
+
+`div_t`'s `std::formatter` specialization delegates to
 `std::formatter<std::tuple<T const&, T const&>>` through `std::tie`, rather
 than formatting `quot`/`rem` by hand, so it automatically inherits
 whatever formatting C++23 standard libraries give tuple-like values
 (delimiters, nesting, etc.) instead of hardcoding a "(quot, rem)" layout
 that could drift from what the standard library does elsewhere.
 
-Each type also has a narrow `std::ostream& operator<<` overload (no
+Being a partial specialization over `div_t`'s element type rather than four
+explicit specializations has a side benefit: the body is instantiated at the
+point of use, so merely including `<xstd/cstdlib.hpp>` no longer requires a
+standard library that implements tuple formatting. Only actually formatting
+an `xstd::div_t` does.
+
+`div_t` also has a narrow `std::ostream& operator<<` overload (no
 wide-character support) that just forwards to `std::format`. This exists
-solely so Boost.Test can print these types in test diagnostics on
-assertion failure - it is not a general-purpose printing facility.
-Application code should prefer `std::format`/`std::print` directly.
+solely so Boost.Test can print the type in test diagnostics on assertion
+failure - it is not a general-purpose printing facility. Application code
+should prefer `std::format`/`std::print` directly.
+
+An explicit deduction guide is declared even though aggregate class template
+argument deduction would already deduce `div_t{q, r}` without one. It makes
+the support intentional rather than incidental, and keeps Clang's
+`-Wctad-maybe-unsupported` (part of the `-Weverything` the tests build with)
+quiet.
 
 ### `xstd::is_specialization_of`
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -142,16 +142,33 @@ for the same reason; C++ has no equivalent, standard or in Boost.Math.
 The strongest self-check the division functions can make is
 `numer == denom * q + r`, and it is only meaningful evaluated in a type wide
 enough that the multiplication itself cannot overflow. As four separate
-overloads, only `div` could make it - `long long` is guaranteed wide enough to
-hold the product of two `int`s, but there was no portable type wider than
-`long long`/`intmax_t` to give `ldiv`/`lldiv`/`imaxdiv` the same guarantee, so
-those three carried a weaker contract with no way to say so once.
+overloads, only `div` made it: `long long` holds the product of *any* two
+`int`s, but there is no portable type wider than `long long`/`intmax_t` to
+give `ldiv`/`lldiv`/`imaxdiv` the same guarantee, so those three carried a
+weaker contract with no way to say so once.
 
-The template states the condition instead of the conclusion:
-`sizeof(T) < sizeof(intmax_t)` decides, per instantiation, whether there is a
-wider type to check in. Widths that have one now get the check whether or not
-they had a name before (`int8_t`, `int16_t`, `int32_t`), and the widest ones
-fall back to the sign and magnitude assertions exactly as they used to.
+"Any two `int`s" is the wrong bound, though. The operands are not arbitrary
+values of `T`; `q` is `numer` divided by `denom`, which pins the product much
+more tightly - and pins it differently for each convention:
+
+- **Truncated division needs no widening at all.** `denom * qT` is exactly
+  `numer - rT`, and `rT` carries `numer`'s sign, so the product lies between
+  `0` and `numer` inclusive and is representable wherever `numer` is. `div`
+  asserts the identity in `T` itself, unconditionally - which finally gives
+  the check at `intmax_t` width, where neither the old `imaxdiv` nor a
+  `sizeof`-gated template would have had it.
+- **The adjusted quotients do need it.** `euclidean_div` and `floored_div`
+  move the remainder across zero, so `denom * q = numer - r` can land one unit
+  of `|denom|` outside `T`: for `int32_t`, `numer == INT32_MIN` with
+  `denom == 3` gives `denom * qE == INT32_MIN - 1`. An exhaustive sweep of
+  every in-contract `int8_t` pair finds 5698 such products for Euclidean and
+  5825 for floored, against zero for truncated. The excess is bounded by
+  `|numer| + |denom| < 2^N`, so one extra bit suffices and any wider signed
+  type will do.
+
+The gate `sizeof(T) < sizeof(intmax_t)` therefore applies only to the two
+adjusted conventions, and only they fall back to the sign and magnitude
+assertions at the widest width.
 
 ### `xstd::div_t` formatting
 

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -93,15 +93,24 @@ div_t(T, T) -> div_t<T>;
 
 namespace detail {
 
-// The division contracts' strongest self-check is the back-multiplication
-// numer == denom * q + r, which is only meaningful when evaluated in a type
-// wide enough that the multiplication itself cannot overflow. |denom * q| is
-// at most |numer| < 2^(N-1) for an N-bit T, so any signed type wider than T
-// suffices, and intmax_t is the widest one portably available. For a T that
-// is already intmax_t-wide there is nothing to widen to, and the sign and
-// magnitude assertions below have to carry the contract on their own - the
-// same tradeoff the non-template ldiv/lldiv/imaxdiv made, now stated once
-// and applied at whichever widths actually need it.
+// Whether the back-multiplication self-check numer == denom * q + r can be
+// evaluated without the product overflowing depends on which q it is.
+//
+// For truncated division it always can, in T itself: denom * qT is exactly
+// numer - rT, and rT carries numer's sign, so the product lies between 0 and
+// numer inclusive and is representable wherever numer is. No widening, at
+// any width.
+//
+// The adjusted quotients are the ones that need room. euclidean_div and
+// floored_div move the remainder across zero, so denom * q = numer - r can
+// land one unit of |denom| outside T - int32_t's numer == INT32_MIN with
+// denom == 3 gives denom * qE == INT32_MIN - 1. The excess is bounded by
+// |numer| + |denom| < 2^N for an N-bit T, so one extra bit is enough and any
+// wider signed type will do; intmax_t is the widest portably available. For a
+// T that is already intmax_t-wide there is nothing to widen to, and the sign
+// and magnitude assertions have to carry the contract on their own - the same
+// tradeoff the non-template ldiv/lldiv/imaxdiv made, now stated once and
+// applied only where it actually bites.
 template<std::signed_integral T>
 inline constexpr auto has_wider_type = sizeof(T) < sizeof(std::intmax_t);
 
@@ -123,9 +132,7 @@ template<std::signed_integral T>
         assert(!(numer == std::numeric_limits<T>::min() && denom == -1));
         auto const qT = static_cast<T>(numer / denom);
         auto const rT = static_cast<T>(numer % denom);
-        if constexpr (detail::has_wider_type<T>) {
-                assert(static_cast<std::intmax_t>(numer) == (static_cast<std::intmax_t>(denom) * qT) + rT);
-        }
+        assert(numer == (denom * qT) + rT); // see detail::has_wider_type: safe in T at every width
         assert(uabs(rT) < uabs(denom));
         assert(sign(rT) == sign(numer) || rT == 0);
         return {.quot = qT, .rem = rT};

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -8,7 +8,6 @@
 
 #include <cassert>     // assert
 #include <concepts>    // signed_integral
-#include <cstdint>     // intmax_t
 #include <format>      // format, formatter
 #include <limits>      // numeric_limits
 #include <ostream>     // ostream
@@ -91,31 +90,6 @@ struct div_t
 template<std::signed_integral T>
 div_t(T, T) -> div_t<T>;
 
-namespace detail {
-
-// Whether the back-multiplication self-check numer == denom * q + r can be
-// evaluated without the product overflowing depends on which q it is.
-//
-// For truncated division it always can, in T itself: denom * qT is exactly
-// numer - rT, and rT carries numer's sign, so the product lies between 0 and
-// numer inclusive and is representable wherever numer is. No widening, at
-// any width.
-//
-// The adjusted quotients are the ones that need room. euclidean_div and
-// floored_div move the remainder across zero, so denom * q = numer - r can
-// land one unit of |denom| outside T - int32_t's numer == INT32_MIN with
-// denom == 3 gives denom * qE == INT32_MIN - 1. The excess is bounded by
-// |numer| + |denom| < 2^N for an N-bit T, so one extra bit is enough and any
-// wider signed type will do; intmax_t is the widest portably available. For a
-// T that is already intmax_t-wide there is nothing to widen to, and the sign
-// and magnitude assertions have to carry the contract on their own - the same
-// tradeoff the non-template ldiv/lldiv/imaxdiv made, now stated once and
-// applied only where it actually bites.
-template<std::signed_integral T>
-inline constexpr auto has_wider_type = sizeof(T) < sizeof(std::intmax_t);
-
-} // namespace detail
-
 // C++ Standard [expr.mul]/4
 // https://en.wikipedia.org/wiki/Modulo_operation
 // http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf
@@ -132,7 +106,14 @@ template<std::signed_integral T>
         assert(!(numer == std::numeric_limits<T>::min() && denom == -1));
         auto const qT = static_cast<T>(numer / denom);
         auto const rT = static_cast<T>(numer % denom);
-        assert(numer == (denom * qT) + rT); // see detail::has_wider_type: safe in T at every width
+        // Safe in T at every width, with no widening: denom * qT is exactly
+        // numer - rT, and rT carries numer's sign, so the product lies between
+        // 0 and numer inclusive and is representable wherever numer is. This
+        // is the only one of the three conventions where the identity is worth
+        // asserting - it checks the built-in / and % against each other. For
+        // the two below it is an algebraic consequence of how they adjust qT
+        // and rT, so it could only fail if this one had already failed.
+        assert(numer == (denom * qT) + rT);
         assert(uabs(rT) < uabs(denom));
         assert(sign(rT) == sign(numer) || rT == 0);
         return {.quot = qT, .rem = rT};
@@ -146,12 +127,17 @@ template<std::signed_integral T>
 {
         assert(denom != 0);
         auto const divT = div(numer, denom);
-        auto const I = divT.rem >= 0 ? T{0} : (denom > 0 ? T{1} : T{-1});
-        auto const qE = static_cast<T>(divT.quot - I);
-        auto const rE = static_cast<T>(divT.rem + (I * denom));
-        if constexpr (detail::has_wider_type<T>) {
-                assert(static_cast<std::intmax_t>(numer) == (static_cast<std::intmax_t>(denom) * qE) + rE);
+        if (divT.rem >= 0) {
+                return divT;
         }
+        // A negative truncated remainder is moved up by one |denom|, and the
+        // quotient compensated in the matching direction. Spelled as an add or
+        // a subtract of denom rather than as rem + I * denom with I == -1:
+        // denom == MIN is in contract here and -MIN is not representable, so
+        // the multiplication would overflow. (floored_div below only ever
+        // scales denom by 0 or 1, so it has no such case.)
+        auto const qE = static_cast<T>(denom > 0 ? divT.quot - 1 : divT.quot + 1);
+        auto const rE = static_cast<T>(denom > 0 ? divT.rem + denom : divT.rem - denom);
         assert(uabs(rE) < uabs(denom));
         assert(sign(rE) >= 0);
         return {.quot = qE, .rem = rE};
@@ -169,9 +155,6 @@ template<std::signed_integral T>
         auto const I = sign(divT.rem) == -sign(denom) ? T{1} : T{0};
         auto const qF = static_cast<T>(divT.quot - I);
         auto const rF = static_cast<T>(divT.rem + (I * denom));
-        if constexpr (detail::has_wider_type<T>) {
-                assert(static_cast<std::intmax_t>(numer) == (static_cast<std::intmax_t>(denom) * qF) + rF);
-        }
         assert(uabs(rF) < uabs(denom));
         assert(rF == 0 || sign(rF) == sign(denom));
         return {.quot = qF, .rem = rF};

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -127,17 +127,16 @@ template<std::signed_integral T>
 {
         assert(denom != 0);
         auto const divT = div(numer, denom);
-        if (divT.rem >= 0) {
-                return divT;
-        }
-        // A negative truncated remainder is moved up by one |denom|, and the
-        // quotient compensated in the matching direction. Spelled as an add or
-        // a subtract of denom rather than as rem + I * denom with I == -1:
-        // denom == MIN is in contract here and -MIN is not representable, so
-        // the multiplication would overflow. (floored_div below only ever
-        // scales denom by 0 or 1, so it has no such case.)
-        auto const qE = static_cast<T>(denom > 0 ? divT.quot - 1 : divT.quot + 1);
-        auto const rE = static_cast<T>(denom > 0 ? divT.rem + denom : divT.rem - denom);
+        // A negative truncated remainder is moved up by one |denom|, with the
+        // quotient compensated in the matching direction. The remainder's
+        // adjustment is spelled as an add or a subtract of denom rather than
+        // as rem + I * denom: denom == MIN is in contract here and -MIN is not
+        // representable, so forming I * denom with I == -1 would overflow.
+        // (floored_div below only ever scales denom by 0 or 1, so it has no
+        // such case.)
+        auto const I = divT.rem >= 0 ? T{0} : (denom > 0 ? T{1} : T{-1});
+        auto const qE = static_cast<T>(divT.quot - I);
+        auto const rE = static_cast<T>(I == 0 ? divT.rem : (denom > 0 ? divT.rem + denom : divT.rem - denom));
         assert(uabs(rE) < uabs(denom));
         assert(sign(rE) >= 0);
         return {.quot = qE, .rem = rE};
@@ -152,9 +151,14 @@ template<std::signed_integral T>
 {
         assert(denom != 0);
         auto const divT = div(numer, denom);
-        auto const I = sign(divT.rem) == -sign(denom) ? T{1} : T{0};
-        auto const qF = static_cast<T>(divT.quot - I);
-        auto const rF = static_cast<T>(divT.rem + (I * denom));
+        // The same adjustment as euclidean_div above, but two-valued rather
+        // than three: a remainder whose sign differs from denom's is moved one
+        // denom in denom's direction, and the quotient compensated. So no I to
+        // scale denom by - that factor could only ever be 0 or 1, which makes
+        // the multiplication a select written the long way round.
+        auto const adjust = sign(divT.rem) == -sign(denom);
+        auto const qF = static_cast<T>(adjust ? divT.quot - 1 : divT.quot);
+        auto const rF = static_cast<T>(adjust ? divT.rem + denom : divT.rem);
         assert(uabs(rF) < uabs(denom));
         assert(rF == 0 || sign(rF) == sign(denom));
         return {.quot = qF, .rem = rF};

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -6,227 +6,147 @@
 #ifndef XSTD_CSTDLIB_HPP
 #define XSTD_CSTDLIB_HPP
 
-#include <cassert> // assert
-#include <cstdint> // intmax_t, uintmax_t
-#include <format>  // format, formatter
-#include <limits>  // numeric_limits
-#include <ostream> // ostream
-#include <tuple>   // tie, tuple
+#include <cassert>     // assert
+#include <concepts>    // signed_integral
+#include <cstdint>     // intmax_t
+#include <format>      // format, formatter
+#include <limits>      // numeric_limits
+#include <ostream>     // ostream
+#include <tuple>       // tie, tuple
+#include <type_traits> // make_unsigned_t
 
 namespace xstd {
 
-// constexpr versions of <cstdlib>'s abs/labs/llabs and <cinttypes>'s imaxabs
-// (P0533), with the same non-template, signed-only signatures as those
-// headers themselves.
-[[nodiscard]] constexpr int abs(int x) noexcept
+// Each facility below is a single function template constrained to
+// std::signed_integral, rather than the <cstdlib>-style family of four
+// fixed-width overloads (abs/labs/llabs/imaxabs and friends) these grew out
+// of. Consequences worth knowing at the call site:
+//
+// - The exact-width types are covered for free. int8_t/int16_t/int32_t/
+//   int64_t are aliases of signed char/short/int/long/long long, so a
+//   template over std::signed_integral instantiates for each of them,
+//   including the two narrow widths the <cstdlib> naming has no name for.
+// - The result type is the argument type, not the promoted type. Passing an
+//   int16_t no longer silently widens to int the way a call to a non-template
+//   abs(int) did; abs(x) of an int16_t is an int16_t, and its precondition is
+//   int16_t's, not int's. Callers who want the old promoting behavior can
+//   write abs(+x) or abs<int>(x).
+// - The two-argument templates deduce a single T from both arguments, so a
+//   mixed-width call like div(8, 3L) is a deduction failure rather than a
+//   silent conversion. Spell the intent as div<long>(8, 3L) or cast.
+// - 128-bit integers are deliberately not covered: neither __int128 nor
+//   unsigned __int128 satisfies std::integral in the strictly conforming
+//   dialect this library targets, and libstdc++'s std::make_unsigned is a
+//   hard error rather than a substitution failure for them. Widening the
+//   constraint is a one-line change if that ever becomes portable; see
+//   doc/design.md.
+
+// constexpr version of <cstdlib>'s abs/labs/llabs and <cinttypes>'s imaxabs
+// (P0533), generalized to one signed-only template.
+template<std::signed_integral T>
+[[nodiscard]] constexpr T abs(T x) noexcept
 {
-        assert(x != std::numeric_limits<int>::min()); // -x would overflow
-        return x < 0 ? -x : x;
+        assert(x != std::numeric_limits<T>::min()); // -x would overflow
+        return x < 0 ? static_cast<T>(-x) : x;
 }
 
-[[nodiscard]] constexpr long labs(long x) noexcept
+// The total counterpart of abs: same |x|, but returning the unsigned type, so
+// the one input abs has to exclude - the most negative value, whose magnitude
+// is one past the signed maximum - is in contract here. Negation is done by
+// unsigned wraparound, which is well-defined, rather than by -x on a signed
+// MIN, which is not, or by widening to a bigger signed type, which has none
+// to widen to at the widest end.
+template<std::signed_integral T>
+[[nodiscard]] constexpr std::make_unsigned_t<T> uabs(T x) noexcept
 {
-        assert(x != std::numeric_limits<long>::min()); // -x would overflow
-        return x < 0 ? -x : x;
+        using U = std::make_unsigned_t<T>;
+        auto const u = static_cast<U>(x);
+        // The cast back to U is what makes this wraparound rather than
+        // promotion: for types narrower than int, U{0} - u is evaluated in
+        // int and is negative, and converting that back to U reduces it mod
+        // 2^N - exactly the value the wider unsigned types get directly.
+        return x < 0 ? static_cast<U>(U{0} - u) : u;
 }
 
-[[nodiscard]] constexpr long long llabs(long long x) noexcept
-{
-        assert(x != std::numeric_limits<long long>::min()); // -x would overflow
-        return x < 0 ? -x : x;
-}
-
-[[nodiscard]] constexpr std::intmax_t imaxabs(std::intmax_t x) noexcept
-{
-        assert(x != std::numeric_limits<std::intmax_t>::min()); // -x would overflow
-        return x < 0 ? -x : x;
-}
-
-// The total counterpart of the abs family above: same |x|, but returning the
-// unsigned type, so the one input abs has to exclude - the most negative
-// value, whose magnitude is one past the signed maximum - is in contract
-// here. Negation is done by unsigned wraparound, which is well-defined,
-// rather than by -x on a signed MIN, which is not, or by widening to a
-// bigger signed type, which has none to widen to at the intmax_t end.
-// Same four widths and the same non-template style as abs, and likewise
-// distinct names rather than an overload set: long and intmax_t are the same
-// type on some platforms (e.g. 64-bit Linux) and distinct on others, so
-// overloads could collide there.
-[[nodiscard]] constexpr unsigned uabs(int x) noexcept
-{
-        return x < 0 ? static_cast<unsigned>(0) - static_cast<unsigned>(x) : static_cast<unsigned>(x);
-}
-
-[[nodiscard]] constexpr unsigned long ulabs(long x) noexcept
-{
-        return x < 0 ? static_cast<unsigned long>(0) - static_cast<unsigned long>(x) : static_cast<unsigned long>(x);
-}
-
-[[nodiscard]] constexpr unsigned long long ullabs(long long x) noexcept
-{
-        return x < 0 ? static_cast<unsigned long long>(0) - static_cast<unsigned long long>(x) : static_cast<unsigned long long>(x);
-}
-
-[[nodiscard]] constexpr std::uintmax_t uimaxabs(std::intmax_t x) noexcept
-{
-        return x < 0 ? static_cast<std::uintmax_t>(0) - static_cast<std::uintmax_t>(x) : static_cast<std::uintmax_t>(x);
-}
-
-// not part of <cstdlib>, but kept to the same style and the same four
-// widths as the abs family above: plain integral types, no templates.
-[[nodiscard]] constexpr int sign(int x) noexcept
+// not part of <cstdlib>, but kept to the same shape as abs/uabs above. The
+// result is a plain int at every width: a sign is a three-valued quantity,
+// not a number in T's range.
+template<std::signed_integral T>
+[[nodiscard]] constexpr int sign(T x) noexcept
 {
         return static_cast<int>(0 < x) - static_cast<int>(x < 0);
 }
 
-[[nodiscard]] constexpr int lsign(long x) noexcept
-{
-        return static_cast<int>(0 < x) - static_cast<int>(x < 0);
-}
-
-[[nodiscard]] constexpr int llsign(long long x) noexcept
-{
-        return static_cast<int>(0 < x) - static_cast<int>(x < 0);
-}
-
-[[nodiscard]] constexpr int imaxsign(std::intmax_t x) noexcept
-{
-        return static_cast<int>(0 < x) - static_cast<int>(x < 0);
-}
-
+template<std::signed_integral T>
 struct div_t
 {
-        int quot, rem;
+        T quot, rem;
         [[nodiscard]] friend constexpr bool operator==(div_t const&, div_t const&) noexcept = default;
 };
 
-struct ldiv_t
-{
-        long quot, rem;
-        [[nodiscard]] friend constexpr bool operator==(ldiv_t const&, ldiv_t const&) noexcept = default;
-};
+// Aggregate class template argument deduction would already deduce this, but
+// spelling the guide out makes the support intentional rather than incidental
+// (and keeps -Wctad-maybe-unsupported quiet), so div_t{q, r} remains as
+// writable as the four separate div_t/ldiv_t/lldiv_t/imaxdiv_t names were.
+template<std::signed_integral T>
+div_t(T, T) -> div_t<T>;
 
-struct lldiv_t
-{
-        long long quot, rem;
-        [[nodiscard]] friend constexpr bool operator==(lldiv_t const&, lldiv_t const&) noexcept = default;
-};
+namespace detail {
 
-struct imaxdiv_t
-{
-        std::intmax_t quot, rem;
-        [[nodiscard]] friend constexpr bool operator==(imaxdiv_t const&, imaxdiv_t const&) noexcept = default;
-};
+// The division contracts' strongest self-check is the back-multiplication
+// numer == denom * q + r, which is only meaningful when evaluated in a type
+// wide enough that the multiplication itself cannot overflow. |denom * q| is
+// at most |numer| < 2^(N-1) for an N-bit T, so any signed type wider than T
+// suffices, and intmax_t is the widest one portably available. For a T that
+// is already intmax_t-wide there is nothing to widen to, and the sign and
+// magnitude assertions below have to carry the contract on their own - the
+// same tradeoff the non-template ldiv/lldiv/imaxdiv made, now stated once
+// and applied at whichever widths actually need it.
+template<std::signed_integral T>
+inline constexpr auto has_wider_type = sizeof(T) < sizeof(std::intmax_t);
+
+} // namespace detail
 
 // C++ Standard [expr.mul]/4
 // https://en.wikipedia.org/wiki/Modulo_operation
 // http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf
 
-// constexpr versions of <cstdlib>'s div/ldiv/lldiv and <cinttypes>'s
-// imaxdiv. The back-multiplication self-check (numer == denom * q + r,
-// verified in a type wide enough that the multiplication itself can't
-// overflow) is only possible for div: long long is guaranteed wide enough
-// to hold the product of two ints, but there is no portable type wider than
-// long long/intmax_t to give the same guarantee for the other three, so
-// those rely solely on the sign and magnitude assertions below.
+// constexpr version of <cstdlib>'s div/ldiv/lldiv and <cinttypes>'s imaxdiv.
 // %: C99, C++11, C#, D, F#, Go, Java, Javascript, PHP, Rust, Scala, Swift
 // rem: Ada, Clojure, Erlang, Haskell, Julia, Lisp, Prolog
 // remainder: Ruby, Scheme
 // mod: Fortran, OCaml
-[[nodiscard]] constexpr div_t div(int numer, int denom) noexcept
+template<std::signed_integral T>
+[[nodiscard]] constexpr div_t<T> div(T numer, T denom) noexcept
 {
         assert(denom != 0);
-        assert(!(numer == std::numeric_limits<int>::min() && denom == -1));
-        auto const qT = numer / denom;
-        auto const rT = numer % denom;
-        assert(static_cast<long long>(numer) == (static_cast<long long>(denom) * qT) + rT);
+        assert(!(numer == std::numeric_limits<T>::min() && denom == -1));
+        auto const qT = static_cast<T>(numer / denom);
+        auto const rT = static_cast<T>(numer % denom);
+        if constexpr (detail::has_wider_type<T>) {
+                assert(static_cast<std::intmax_t>(numer) == (static_cast<std::intmax_t>(denom) * qT) + rT);
+        }
         assert(uabs(rT) < uabs(denom));
         assert(sign(rT) == sign(numer) || rT == 0);
-        return {.quot = qT, .rem = rT};
-}
-
-[[nodiscard]] constexpr ldiv_t ldiv(long numer, long denom) noexcept
-{
-        assert(denom != 0);
-        assert(!(numer == std::numeric_limits<long>::min() && denom == -1));
-        auto const qT = numer / denom;
-        auto const rT = numer % denom;
-        assert(ulabs(rT) < ulabs(denom));
-        assert(lsign(rT) == lsign(numer) || rT == 0);
-        return {.quot = qT, .rem = rT};
-}
-
-[[nodiscard]] constexpr lldiv_t lldiv(long long numer, long long denom) noexcept
-{
-        assert(denom != 0);
-        assert(!(numer == std::numeric_limits<long long>::min() && denom == -1));
-        auto const qT = numer / denom;
-        auto const rT = numer % denom;
-        assert(ullabs(rT) < ullabs(denom));
-        assert(llsign(rT) == llsign(numer) || rT == 0);
-        return {.quot = qT, .rem = rT};
-}
-
-[[nodiscard]] constexpr imaxdiv_t imaxdiv(std::intmax_t numer, std::intmax_t denom) noexcept
-{
-        assert(denom != 0);
-        assert(!(numer == std::numeric_limits<std::intmax_t>::min() && denom == -1));
-        auto const qT = numer / denom;
-        auto const rT = numer % denom;
-        assert(uimaxabs(rT) < uimaxabs(denom));
-        assert(imaxsign(rT) == imaxsign(numer) || rT == 0);
         return {.quot = qT, .rem = rT};
 }
 
 // https://en.wikipedia.org/wiki/Euclidean_division
 // mod: Maple, Pascal
 // modulo: Scheme
-[[nodiscard]] constexpr div_t euclidean_div(int numer, int denom) noexcept
+template<std::signed_integral T>
+[[nodiscard]] constexpr div_t<T> euclidean_div(T numer, T denom) noexcept
 {
         assert(denom != 0);
         auto const divT = div(numer, denom);
-        auto const I = divT.rem >= 0 ? 0 : (denom > 0 ? 1 : -1);
-        auto const qE = divT.quot - I;
-        auto const rE = divT.rem + (I * denom);
-        assert(static_cast<long long>(numer) == (static_cast<long long>(denom) * qE) + rE);
+        auto const I = divT.rem >= 0 ? T{0} : (denom > 0 ? T{1} : T{-1});
+        auto const qE = static_cast<T>(divT.quot - I);
+        auto const rE = static_cast<T>(divT.rem + (I * denom));
+        if constexpr (detail::has_wider_type<T>) {
+                assert(static_cast<std::intmax_t>(numer) == (static_cast<std::intmax_t>(denom) * qE) + rE);
+        }
         assert(uabs(rE) < uabs(denom));
         assert(sign(rE) >= 0);
-        return {.quot = qE, .rem = rE};
-}
-
-[[nodiscard]] constexpr ldiv_t euclidean_ldiv(long numer, long denom) noexcept
-{
-        assert(denom != 0);
-        auto const divT = ldiv(numer, denom);
-        auto const I = divT.rem >= 0 ? 0L : (denom > 0 ? 1L : -1L);
-        auto const qE = divT.quot - I;
-        auto const rE = divT.rem + (I * denom);
-        assert(ulabs(rE) < ulabs(denom));
-        assert(lsign(rE) >= 0);
-        return {.quot = qE, .rem = rE};
-}
-
-[[nodiscard]] constexpr lldiv_t euclidean_lldiv(long long numer, long long denom) noexcept
-{
-        assert(denom != 0);
-        auto const divT = lldiv(numer, denom);
-        auto const I = divT.rem >= 0 ? 0LL : (denom > 0 ? 1LL : -1LL);
-        auto const qE = divT.quot - I;
-        auto const rE = divT.rem + (I * denom);
-        assert(ullabs(rE) < ullabs(denom));
-        assert(llsign(rE) >= 0);
-        return {.quot = qE, .rem = rE};
-}
-
-[[nodiscard]] constexpr imaxdiv_t euclidean_imaxdiv(std::intmax_t numer, std::intmax_t denom) noexcept
-{
-        assert(denom != 0);
-        auto const divT = imaxdiv(numer, denom);
-        auto const I = divT.rem >= 0 ? std::intmax_t{0} : (denom > 0 ? std::intmax_t{1} : std::intmax_t{-1});
-        auto const qE = divT.quot - I;
-        auto const rE = divT.rem + (I * denom);
-        assert(uimaxabs(rE) < uimaxabs(denom));
-        assert(imaxsign(rE) >= 0);
         return {.quot = qE, .rem = rE};
 }
 
@@ -234,122 +154,53 @@ struct imaxdiv_t
 // %%: R
 // mod: Ada, Clojure, Haskell, Julia, Lisp, ML, Prolog
 // modulo: Fortran, Ruby
-[[nodiscard]] constexpr div_t floored_div(int numer, int denom) noexcept
+template<std::signed_integral T>
+[[nodiscard]] constexpr div_t<T> floored_div(T numer, T denom) noexcept
 {
         assert(denom != 0);
         auto const divT = div(numer, denom);
-        auto const I = sign(divT.rem) == -sign(denom) ? 1 : 0;
-        auto const qF = divT.quot - I;
-        auto const rF = divT.rem + (I * denom);
-        assert(static_cast<long long>(numer) == (static_cast<long long>(denom) * qF) + rF);
+        auto const I = sign(divT.rem) == -sign(denom) ? T{1} : T{0};
+        auto const qF = static_cast<T>(divT.quot - I);
+        auto const rF = static_cast<T>(divT.rem + (I * denom));
+        if constexpr (detail::has_wider_type<T>) {
+                assert(static_cast<std::intmax_t>(numer) == (static_cast<std::intmax_t>(denom) * qF) + rF);
+        }
         assert(uabs(rF) < uabs(denom));
         assert(rF == 0 || sign(rF) == sign(denom));
         return {.quot = qF, .rem = rF};
 }
 
-[[nodiscard]] constexpr ldiv_t floored_ldiv(long numer, long denom) noexcept
-{
-        assert(denom != 0);
-        auto const divT = ldiv(numer, denom);
-        auto const I = lsign(divT.rem) == -lsign(denom) ? 1L : 0L;
-        auto const qF = divT.quot - I;
-        auto const rF = divT.rem + (I * denom);
-        assert(ulabs(rF) < ulabs(denom));
-        assert(rF == 0 || lsign(rF) == lsign(denom));
-        return {.quot = qF, .rem = rF};
-}
-
-[[nodiscard]] constexpr lldiv_t floored_lldiv(long long numer, long long denom) noexcept
-{
-        assert(denom != 0);
-        auto const divT = lldiv(numer, denom);
-        auto const I = llsign(divT.rem) == -llsign(denom) ? 1LL : 0LL;
-        auto const qF = divT.quot - I;
-        auto const rF = divT.rem + (I * denom);
-        assert(ullabs(rF) < ullabs(denom));
-        assert(rF == 0 || llsign(rF) == llsign(denom));
-        return {.quot = qF, .rem = rF};
-}
-
-[[nodiscard]] constexpr imaxdiv_t floored_imaxdiv(std::intmax_t numer, std::intmax_t denom) noexcept
-{
-        assert(denom != 0);
-        auto const divT = imaxdiv(numer, denom);
-        auto const I = imaxsign(divT.rem) == -imaxsign(denom) ? std::intmax_t{1} : std::intmax_t{0};
-        auto const qF = divT.quot - I;
-        auto const rF = divT.rem + (I * denom);
-        assert(uimaxabs(rF) < uimaxabs(denom));
-        assert(rF == 0 || imaxsign(rF) == imaxsign(denom));
-        return {.quot = qF, .rem = rF};
-}
-
 } // namespace xstd
 
-// Specialized via qualified-id (template<> struct std::formatter<...>)
+// Specialized via qualified-id (template<class T> struct std::formatter<...>)
 // rather than inside a reopened "namespace std { ... }" block: both forms
 // are equally legal here (the standard explicitly permits specializing
 // std::formatter for program-defined types), but the qualified form avoids
 // clang-tidy's bugprone-std-namespace-modification finding, which otherwise
 // flags any reopening of namespace std regardless of what's inside it.
-template<>
-struct std::formatter<xstd::div_t> : std::formatter<std::tuple<int const&, int const&>>
+//
+// A partial specialization over div_t's element type also defers the body's
+// instantiation to the point of use, so merely including this header no
+// longer requires a standard library that implements tuple formatting; only
+// actually formatting an xstd::div_t does.
+template<class T>
+struct std::formatter<xstd::div_t<T>> : std::formatter<std::tuple<T const&, T const&>>
 {
-        auto format(xstd::div_t const& d, auto& ctx) const
+        auto format(xstd::div_t<T> const& d, auto& ctx) const
         {
-                return std::formatter<std::tuple<int const&, int const&>>::format(std::tie(d.quot, d.rem), ctx);
-        }
-};
-
-template<>
-struct std::formatter<xstd::ldiv_t> : std::formatter<std::tuple<long const&, long const&>>
-{
-        auto format(xstd::ldiv_t const& d, auto& ctx) const
-        {
-                return std::formatter<std::tuple<long const&, long const&>>::format(std::tie(d.quot, d.rem), ctx);
-        }
-};
-
-template<>
-struct std::formatter<xstd::lldiv_t> : std::formatter<std::tuple<long long const&, long long const&>>
-{
-        auto format(xstd::lldiv_t const& d, auto& ctx) const
-        {
-                return std::formatter<std::tuple<long long const&, long long const&>>::format(std::tie(d.quot, d.rem), ctx);
-        }
-};
-
-template<>
-struct std::formatter<xstd::imaxdiv_t> : std::formatter<std::tuple<std::intmax_t const&, std::intmax_t const&>>
-{
-        auto format(xstd::imaxdiv_t const& d, auto& ctx) const
-        {
-                return std::formatter<std::tuple<std::intmax_t const&, std::intmax_t const&>>::format(std::tie(d.quot, d.rem), ctx);
+                return std::formatter<std::tuple<T const&, T const&>>::format(std::tie(d.quot, d.rem), ctx);
         }
 };
 
 namespace xstd {
 
 // narrow std::ostream only, not the full basic_ostream<charT, traits>
-// generality (no wide-character support): these exist solely so
-// Boost.Test can print div_t/ldiv_t/lldiv_t/imaxdiv_t values in test
-// diagnostics. Application code should format these types via
-// std::format/std::print directly rather than through operator<<.
-inline auto& operator<<(std::ostream& ostr, div_t const& d)
-{
-        return ostr << std::format("{}", d);
-}
-
-inline auto& operator<<(std::ostream& ostr, ldiv_t const& d)
-{
-        return ostr << std::format("{}", d);
-}
-
-inline auto& operator<<(std::ostream& ostr, lldiv_t const& d)
-{
-        return ostr << std::format("{}", d);
-}
-
-inline auto& operator<<(std::ostream& ostr, imaxdiv_t const& d)
+// generality (no wide-character support): this exists solely so Boost.Test
+// can print div_t values in test diagnostics. Application code should format
+// these types via std::format/std::print directly rather than through
+// operator<<.
+template<std::signed_integral T>
+auto& operator<<(std::ostream& ostr, div_t<T> const& d)
 {
         return ostr << std::format("{}", d);
 }

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -202,6 +202,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(BoundaryDivisions, T, exact_width_types)
         XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{+1}, min), (xstd::div_t<T>{0, +1}));
         XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{+1}, min), (xstd::div_t<T>{-1, static_cast<T>(min + 1)}));
 
+        // denom == MIN again, but with a negative remainder, which is what
+        // selects euclidean_div's negative adjustment. Computing that one as
+        // rem + I * denom would form -MIN and overflow; being a constant
+        // expression, this check catches that at compile time as well as
+        // under a sanitizer. Promotion hides it below int, so the wider
+        // instantiations of this case are the ones that matter.
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{-1}, min), (xstd::div_t<T>{0, -1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{-1}, min), (xstd::div_t<T>{+1, max}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{-1}, min), (xstd::div_t<T>{0, -1}));
+
         XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(max, T{-1}), (xstd::div_t<T>{static_cast<T>(-max), 0}));
         XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(max, T{-1}), (xstd::div_t<T>{static_cast<T>(-max), 0}));
         XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(max, T{-1}), (xstd::div_t<T>{static_cast<T>(-max), 0}));

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -226,32 +226,61 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(StreamInsertion, T, exact_width_types)
 // int8_t/../int64_t are aliases of the built-in types, but which alias maps
 // to which built-in one is platform-dependent: on LP64 int64_t is long and
 // long long is never instantiated above, on LLP64 it is the other way around.
-// One representative call per built-in width closes that gap without
-// registering a second test case for a type the list above already covers.
+// This battery closes that gap for whichever built-in width the exact-width
+// list happens to miss. A plain function template rather than a second
+// BOOST_AUTO_TEST_CASE_TEMPLATE, since the two lists overlap on every
+// platform and duplicate registration of a test case name is an error.
+//
+// It has to exercise both arms of every conditional rather than call each
+// function once. A single call per width leaves euclidean_div's and
+// floored_div's remainder adjustments half-covered, and leaves div_t's
+// formatter and operator<< instantiated - Boost.Test's printing machinery
+// instantiates them for anything it might have to report - but never
+// executed, since they only run when an assertion fails.
+template<std::signed_integral T>
+void check_built_in_width()
+{
+        using U = std::make_unsigned_t<T>;
+        using limits = std::numeric_limits<T>;
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(T{-2}), T{2});
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(T{+2}), T{2});
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(T{+2}), U{2});
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(limits::min()), static_cast<U>(static_cast<U>(limits::max()) + U{1}));
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(T{-2}), -1);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(T{0}), 0);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(T{+2}), +1);
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{+8}, T{+3}), (xstd::div_t<T>{+2, +2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{-8}, T{+3}), (xstd::div_t<T>{-2, -2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{-8}, T{-3}), (xstd::div_t<T>{+2, -2}));
+
+        // A nonnegative remainder, then a negative one against each sign of
+        // denom: all three arms of euclidean_div's adjustment, and both of
+        // floored_div's.
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{+8}, T{+3}), (xstd::div_t<T>{+2, +2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{-8}, T{+3}), (xstd::div_t<T>{-3, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{-8}, T{-3}), (xstd::div_t<T>{+3, +1}));
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{+8}, T{+3}), (xstd::div_t<T>{+2, +2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{-8}, T{+3}), (xstd::div_t<T>{-3, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{-8}, T{-3}), (xstd::div_t<T>{+2, -2}));
+
+        BOOST_CHECK_EQUAL(std::format("{}", xstd::div_t<T>{1, -2}), "(1, -2)");
+
+        std::ostringstream oss;
+        oss << xstd::div_t<T>{1, -2};
+        BOOST_CHECK_EQUAL(oss.str(), "(1, -2)");
+}
+
 BOOST_AUTO_TEST_CASE(BuiltInWidths)
 {
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-8, +3), (xstd::div_t{-2, -2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-8L, +3L), (xstd::div_t{-2L, -2L}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-8LL, +3LL), (xstd::div_t{-2LL, -2LL}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(std::intmax_t{-8}, std::intmax_t{+3}), (xstd::div_t{std::intmax_t{-2}, std::intmax_t{-2}}));
-
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-8, +3), (xstd::div_t{-3, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-8L, +3L), (xstd::div_t{-3L, +1L}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-8LL, +3LL), (xstd::div_t{-3LL, +1LL}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(std::intmax_t{-8}, std::intmax_t{+3}), (xstd::div_t{std::intmax_t{-3}, std::intmax_t{+1}}));
-
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-8, +3), (xstd::div_t{-3, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-8L, +3L), (xstd::div_t{-3L, +1L}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-8LL, +3LL), (xstd::div_t{-3LL, +1LL}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(std::intmax_t{-8}, std::intmax_t{+3}), (xstd::div_t{std::intmax_t{-3}, std::intmax_t{+1}}));
-
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(-2), 2);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(-2L), 2L);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(-2LL), 2LL);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(std::intmax_t{-2}), std::intmax_t{2});
-
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(std::numeric_limits<long long>::min()), static_cast<unsigned long long>(std::numeric_limits<long long>::max()) + 1ULL);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(-2LL), -1);
+        check_built_in_width<int>();
+        check_built_in_width<long>();
+        check_built_in_width<long long>();
+        check_built_in_width<std::intmax_t>();
 }
 
 // Class template argument deduction: div_t{q, r} still spells the result of

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -3,101 +3,268 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <xstd/cstdlib.hpp>         // /u?(l{0,2}|imax)(abs|sign|div_t?)/, /(euclidean|floored)_(l{0,2}|imax)div/
+#include <xstd/cstdlib.hpp>         // abs, uabs, sign, div_t, div, euclidean_div, floored_div
 #include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK_EQUAL
-#include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_CHECK_EQUAL, BOOST_CHECK_EQUAL_COLLECTIONS
+#include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_CHECK_EQUAL, BOOST_CHECK_EQUAL_COLLECTIONS
 #include <algorithm>                // transform
 #include <array>                    // array
-#include <cstdint>                  // intmax_t
-#include <cstdlib>                  // div, div_t
+#include <concepts>                 // same_as
+#include <cstdint>                  // int8_t, int16_t, int32_t, int64_t, intmax_t
+#include <cstdlib>                  // div
 #include <format>                   // format
 #include <iterator>                 // back_inserter
 #include <limits>                   // numeric_limits
 #include <sstream>                  // ostringstream
+#include <tuple>                    // tuple
+#include <type_traits>              // make_unsigned_t
 #include <utility>                  // pair
 #include <vector>                   // vector
 
 BOOST_AUTO_TEST_SUITE(CStdLib)
 
-BOOST_AUTO_TEST_CASE(Abs)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(-2), 2);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(-1), 1);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(0), 0);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(+1), 1);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(+2), 2);
+// The exact-width signed types, which is what a std::signed_integral-
+// constrained template buys over the <cstdlib>-style abs/labs/llabs/imaxabs
+// naming: int8_t and int16_t have no name in that scheme at all, and the two
+// that do (int32_t, int64_t) no longer need one. 128-bit integers are absent
+// on purpose - see the note at the top of <xstd/cstdlib.hpp>.
+using exact_width_types = std::tuple<std::int8_t, std::int16_t, std::int32_t, std::int64_t>;
 
-        using limits = std::numeric_limits<int>;
+// Named concepts rather than bare requires-expressions in the test bodies:
+// a requires-expression whose operand is invalid *and* non-dependent is a
+// hard error on GCC, so the type has to stay a template parameter.
+template<class T>
+concept has_abs = requires (T x) { xstd::abs(x); };
+
+template<class T>
+concept has_uabs = requires (T x) { xstd::uabs(x); };
+
+template<class T>
+concept has_sign = requires (T x) { xstd::sign(x); };
+
+template<class T, class U>
+concept has_div = requires (T numer, U denom) { xstd::div(numer, denom); };
+
+// The constraint itself: signed integral in, nothing else, and the argument
+// type comes back out rather than the promoted type.
+BOOST_AUTO_TEST_CASE_TEMPLATE(Constraints, T, exact_width_types)
+{
+        static_assert(std::same_as<decltype(xstd::abs(T{})), T>);
+        static_assert(std::same_as<decltype(xstd::uabs(T{})), std::make_unsigned_t<T>>);
+        static_assert(std::same_as<decltype(xstd::sign(T{})), int>);
+        static_assert(std::same_as<decltype(xstd::div(T{1}, T{1})), xstd::div_t<T>>);
+        static_assert(std::same_as<decltype(xstd::euclidean_div(T{1}, T{1})), xstd::div_t<T>>);
+        static_assert(std::same_as<decltype(xstd::floored_div(T{1}, T{1})), xstd::div_t<T>>);
+
+        static_assert(has_abs<T>);
+        static_assert(has_uabs<T>);
+        static_assert(has_sign<T>);
+        static_assert(has_div<T, T>);
+
+        // Unsigned arguments are outside the constraint, at every width.
+        using U = std::make_unsigned_t<T>;
+        static_assert(!has_abs<U>);
+        static_assert(!has_uabs<U>);
+        static_assert(!has_sign<U>);
+        static_assert(!has_div<U, U>);
+
+        BOOST_CHECK(true); // silence Boost.Test's "test case did not check any assertions"
+}
+
+BOOST_AUTO_TEST_CASE(NonSignedIntegralArgumentsAreRejected)
+{
+        static_assert(!has_abs<bool>);
+        static_assert(!has_abs<double>);
+        static_assert(!has_sign<char*>);
+
+        // Both parameters deduce the same T, so a mixed-width call is a
+        // deduction failure rather than a silent conversion of one operand.
+        static_assert(!has_div<std::int32_t, std::int64_t>);
+        static_assert(std::same_as<decltype(xstd::div<std::int64_t>(8, 3)), xstd::div_t<std::int64_t>>);
+
+        BOOST_CHECK(true);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(Abs, T, exact_width_types)
+{
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(T{-2}), T{2});
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(T{-1}), T{1});
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(T{0}), T{0});
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(T{+1}), T{1});
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(T{+2}), T{2});
+
+        using limits = std::numeric_limits<T>;
         XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(limits::max()), limits::max());
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(limits::min() + 1), limits::max());
-
-        // abs is a plain <cstdlib>-style overload (no template, no unsigned
-        // support): a short argument is promoted to int like any other
-        // call, which keeps it well-defined for short's lowest value.
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(std::numeric_limits<short>::min()), -(std::numeric_limits<short>::min() + 1) + 1);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(static_cast<T>(limits::min() + 1)), limits::max());
 }
 
-BOOST_AUTO_TEST_CASE(Labs)
+// The div families exercise uabs transitively through their assert() guards;
+// check the MIN-boundary wraparound directly and at compile time, since that
+// is both what distinguishes uabs from abs and the one case a widening-based
+// |x| could not have handled - least of all at the widest width, which has
+// nothing to widen to.
+BOOST_AUTO_TEST_CASE_TEMPLATE(UnsignedAbs, T, exact_width_types)
 {
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::labs(-2L), 2L);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::labs(+2L), 2L);
+        using U = std::make_unsigned_t<T>;
 
-        using limits = std::numeric_limits<long>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::labs(limits::max()), limits::max());
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::labs(limits::min() + 1), limits::max());
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(T{-2}), U{2});
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(T{0}), U{0});
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(T{+2}), U{2});
+
+        using limits = std::numeric_limits<T>;
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(limits::min()), static_cast<U>(static_cast<U>(limits::max()) + U{1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(limits::max()), static_cast<U>(limits::max()));
 }
 
-BOOST_AUTO_TEST_CASE(Llabs)
+BOOST_AUTO_TEST_CASE_TEMPLATE(Sign, T, exact_width_types)
 {
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::llabs(-2LL), 2LL);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::llabs(+2LL), 2LL);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(T{-2}), -1);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(T{-1}), -1);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(T{0}), 0);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(T{+1}), +1);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(T{+2}), +1);
 
-        using limits = std::numeric_limits<long long>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::llabs(limits::max()), limits::max());
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::llabs(limits::min() + 1), limits::max());
-}
-
-BOOST_AUTO_TEST_CASE(Imaxabs)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::imaxabs(-2), 2);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::imaxabs(+2), 2);
-
-        using limits = std::numeric_limits<std::intmax_t>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::imaxabs(limits::max()), limits::max());
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::imaxabs(limits::min() + 1), limits::max());
-}
-
-BOOST_AUTO_TEST_CASE(Sign)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(-2), -1);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(-1), -1);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(0), 0);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(+1), +1);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(+2), +1);
-}
-
-BOOST_AUTO_TEST_CASE(Lsign)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::lsign(-2L), -1);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::lsign(0L), 0);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::lsign(+2L), +1);
-}
-
-BOOST_AUTO_TEST_CASE(Llsign)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::llsign(-2LL), -1);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::llsign(0LL), 0);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::llsign(+2LL), +1);
-}
-
-BOOST_AUTO_TEST_CASE(Imaxsign)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::imaxsign(-2), -1);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::imaxsign(0), 0);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::imaxsign(+2), +1);
+        using limits = std::numeric_limits<T>;
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(limits::min()), -1);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(limits::max()), +1);
 }
 
 // http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(TruncatedDiv, T, exact_width_types)
+{
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{+8}, T{+3}), (xstd::div_t<T>{+2, +2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{+8}, T{-3}), (xstd::div_t<T>{-2, +2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{-8}, T{+3}), (xstd::div_t<T>{-2, -2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{-8}, T{-3}), (xstd::div_t<T>{+2, -2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{+1}, T{+2}), (xstd::div_t<T>{0, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{+1}, T{-2}), (xstd::div_t<T>{0, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{-1}, T{+2}), (xstd::div_t<T>{0, -1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{-1}, T{-2}), (xstd::div_t<T>{0, -1}));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(EuclideanDiv, T, exact_width_types)
+{
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{+8}, T{+3}), (xstd::div_t<T>{+2, +2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{+8}, T{-3}), (xstd::div_t<T>{-2, +2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{-8}, T{+3}), (xstd::div_t<T>{-3, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{-8}, T{-3}), (xstd::div_t<T>{+3, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{+1}, T{+2}), (xstd::div_t<T>{0, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{+1}, T{-2}), (xstd::div_t<T>{0, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{-1}, T{+2}), (xstd::div_t<T>{-1, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{-1}, T{-2}), (xstd::div_t<T>{+1, +1}));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(FlooredDiv, T, exact_width_types)
+{
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{+8}, T{+3}), (xstd::div_t<T>{+2, +2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{+8}, T{-3}), (xstd::div_t<T>{-3, -1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{-8}, T{+3}), (xstd::div_t<T>{-3, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{-8}, T{-3}), (xstd::div_t<T>{+2, -2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{+1}, T{+2}), (xstd::div_t<T>{0, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{+1}, T{-2}), (xstd::div_t<T>{-1, -1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{-1}, T{+2}), (xstd::div_t<T>{-1, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{-1}, T{-2}), (xstd::div_t<T>{0, -1}));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ExactDivisions, T, exact_width_types)
+{
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{+6}, T{+3}), (xstd::div_t<T>{+2, 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{+6}, T{+3}), (xstd::div_t<T>{+2, 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{+6}, T{+3}), (xstd::div_t<T>{+2, 0}));
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{+6}, T{-3}), (xstd::div_t<T>{-2, 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{+6}, T{-3}), (xstd::div_t<T>{-2, 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{+6}, T{-3}), (xstd::div_t<T>{-2, 0}));
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{-6}, T{+3}), (xstd::div_t<T>{-2, 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{-6}, T{+3}), (xstd::div_t<T>{-2, 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{-6}, T{+3}), (xstd::div_t<T>{-2, 0}));
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{-6}, T{-3}), (xstd::div_t<T>{+2, 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{-6}, T{-3}), (xstd::div_t<T>{+2, 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{-6}, T{-3}), (xstd::div_t<T>{+2, 0}));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(BoundaryDivisions, T, exact_width_types)
+{
+        using limits = std::numeric_limits<T>;
+        constexpr auto min = limits::min();
+        constexpr auto max = limits::max();
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(min, T{+1}), (xstd::div_t<T>{min, 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(min, T{+1}), (xstd::div_t<T>{min, 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(min, T{+1}), (xstd::div_t<T>{min, 0}));
+
+        // denom == MIN is in contract even though |MIN| is not representable
+        // in T: it is exactly why the postconditions are written with uabs
+        // rather than abs.
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(T{+1}, min), (xstd::div_t<T>{0, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(T{+1}, min), (xstd::div_t<T>{0, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(T{+1}, min), (xstd::div_t<T>{-1, static_cast<T>(min + 1)}));
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(max, T{-1}), (xstd::div_t<T>{static_cast<T>(-max), 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(max, T{-1}), (xstd::div_t<T>{static_cast<T>(-max), 0}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(max, T{-1}), (xstd::div_t<T>{static_cast<T>(-max), 0}));
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(min, max), (xstd::div_t<T>{-1, -1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(min, max), (xstd::div_t<T>{-2, static_cast<T>(max - 1)}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(min, max), (xstd::div_t<T>{-2, static_cast<T>(max - 1)}));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(Formatter, T, exact_width_types)
+{
+        BOOST_CHECK_EQUAL(std::format("{}", xstd::div_t<T>{1, -2}), "(1, -2)");
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(StreamInsertion, T, exact_width_types)
+{
+        std::ostringstream oss;
+        oss << xstd::div_t<T>{1, -2};
+        BOOST_CHECK_EQUAL(oss.str(), "(1, -2)");
+}
+
+// int8_t/../int64_t are aliases of the built-in types, but which alias maps
+// to which built-in one is platform-dependent: on LP64 int64_t is long and
+// long long is never instantiated above, on LLP64 it is the other way around.
+// One representative call per built-in width closes that gap without
+// registering a second test case for a type the list above already covers.
+BOOST_AUTO_TEST_CASE(BuiltInWidths)
+{
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-8, +3), (xstd::div_t{-2, -2}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-8L, +3L), (xstd::div_t{-2L, -2L}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-8LL, +3LL), (xstd::div_t{-2LL, -2LL}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(std::intmax_t{-8}, std::intmax_t{+3}), (xstd::div_t{std::intmax_t{-2}, std::intmax_t{-2}}));
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-8, +3), (xstd::div_t{-3, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-8L, +3L), (xstd::div_t{-3L, +1L}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-8LL, +3LL), (xstd::div_t{-3LL, +1LL}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(std::intmax_t{-8}, std::intmax_t{+3}), (xstd::div_t{std::intmax_t{-3}, std::intmax_t{+1}}));
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-8, +3), (xstd::div_t{-3, +1}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-8L, +3L), (xstd::div_t{-3L, +1L}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-8LL, +3LL), (xstd::div_t{-3LL, +1LL}));
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(std::intmax_t{-8}, std::intmax_t{+3}), (xstd::div_t{std::intmax_t{-3}, std::intmax_t{+1}}));
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(-2), 2);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(-2L), 2L);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(-2LL), 2LL);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::abs(std::intmax_t{-2}), std::intmax_t{2});
+
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(std::numeric_limits<long long>::min()), static_cast<unsigned long long>(std::numeric_limits<long long>::max()) + 1ULL);
+        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::sign(-2LL), -1);
+}
+
+// Class template argument deduction: div_t{q, r} still spells the result of
+// a call to div at the argument's own width, the way the four separate
+// div_t/ldiv_t/lldiv_t/imaxdiv_t names used to.
+BOOST_AUTO_TEST_CASE(DeducedDivT)
+{
+        static_assert(std::same_as<decltype(xstd::div_t{1, 2}), xstd::div_t<int>>);
+        static_assert(std::same_as<decltype(xstd::div_t{1L, 2L}), xstd::div_t<long>>);
+        static_assert(std::same_as<decltype(xstd::div_t{std::int8_t{1}, std::int8_t{2}}), xstd::div_t<std::int8_t>>);
+
+        BOOST_CHECK(true);
+}
 
 // clang-format off
 auto const input = std::array<std::pair<int, int>, 8>
@@ -110,15 +277,15 @@ auto const input = std::array<std::pair<int, int>, 8>
 BOOST_AUTO_TEST_CASE(StdDiv)
 {
         // clang-format off
-        auto const std_div = std::vector<xstd::div_t>
+        auto const std_div = std::vector<xstd::div_t<int>>
         {
                 {+2, +2}, {-2, +2}, {-2, -2}, {+2, -2},
                 { 0, +1}, { 0, +1}, { 0, -1}, { 0, -1}
         };
         // clang-format on
 
-        std::vector<xstd::div_t> std_res;
-        std::transform(input.begin(), input.end(), std::back_inserter(std_res), [](auto const& p) -> xstd::div_t {
+        std::vector<xstd::div_t<int>> std_res;
+        std::transform(input.begin(), input.end(), std::back_inserter(std_res), [](auto const& p) -> xstd::div_t<int> {
                 auto const d = std::div(p.first, p.second);
                 return {d.quot, d.rem};
         });
@@ -126,189 +293,6 @@ BOOST_AUTO_TEST_CASE(StdDiv)
         BOOST_CHECK_EQUAL_COLLECTIONS(
                 std_res.begin(), std_res.end(),
                 std_div.begin(), std_div.end());
-}
-
-BOOST_AUTO_TEST_CASE(TruncatedDiv)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(+8, +3), (xstd::div_t{+2, +2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(+8, -3), (xstd::div_t{-2, +2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-8, +3), (xstd::div_t{-2, -2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-8, -3), (xstd::div_t{+2, -2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(+1, +2), (xstd::div_t{0, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(+1, -2), (xstd::div_t{0, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-1, +2), (xstd::div_t{0, -1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-1, -2), (xstd::div_t{0, -1}));
-}
-
-BOOST_AUTO_TEST_CASE(EuclideanDiv)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(+8, +3), (xstd::div_t{+2, +2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(+8, -3), (xstd::div_t{-2, +2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-8, +3), (xstd::div_t{-3, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-8, -3), (xstd::div_t{+3, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(+1, +2), (xstd::div_t{0, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(+1, -2), (xstd::div_t{0, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-1, +2), (xstd::div_t{-1, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-1, -2), (xstd::div_t{+1, +1}));
-}
-
-BOOST_AUTO_TEST_CASE(ExactDivisions)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(+6, +3), (xstd::div_t{+2, 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(+6, +3), (xstd::div_t{+2, 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(+6, +3), (xstd::div_t{+2, 0}));
-
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(+6, -3), (xstd::div_t{-2, 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(+6, -3), (xstd::div_t{-2, 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(+6, -3), (xstd::div_t{-2, 0}));
-
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-6, +3), (xstd::div_t{-2, 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-6, +3), (xstd::div_t{-2, 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-6, +3), (xstd::div_t{-2, 0}));
-
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(-6, -3), (xstd::div_t{+2, 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(-6, -3), (xstd::div_t{+2, 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-6, -3), (xstd::div_t{+2, 0}));
-}
-
-// The div families exercise uabs/ulabs/ullabs/uimaxabs transitively through
-// their assert() guards; check the MIN-boundary wraparound directly and at
-// compile time, since that is both what distinguishes these from abs and the
-// one case a widening-based |x| could not have handled.
-BOOST_AUTO_TEST_CASE(UnsignedAbs)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(-2), 2u);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(+2), 2u);
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(0), 0u);
-
-        using limits = std::numeric_limits<int>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uabs(limits::min()), static_cast<unsigned>(limits::max()) + 1u);
-
-        using llimits = std::numeric_limits<long>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::ulabs(llimits::min()), static_cast<unsigned long>(llimits::max()) + 1ul);
-
-        using lllimits = std::numeric_limits<long long>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::ullabs(lllimits::min()), static_cast<unsigned long long>(lllimits::max()) + 1ull);
-
-        using imaxlimits = std::numeric_limits<std::intmax_t>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::uimaxabs(imaxlimits::min()), static_cast<std::uintmax_t>(imaxlimits::max()) + std::uintmax_t{1});
-}
-
-BOOST_AUTO_TEST_CASE(BoundaryDivisions)
-{
-        using limits = std::numeric_limits<int>;
-
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(limits::min(), +1), (xstd::div_t{limits::min(), 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(limits::min(), +1), (xstd::div_t{limits::min(), 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(limits::min(), +1), (xstd::div_t{limits::min(), 0}));
-
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(+1, limits::min()), (xstd::div_t{0, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(+1, limits::min()), (xstd::div_t{0, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(+1, limits::min()), (xstd::div_t{-1, limits::min() + 1}));
-
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::div(limits::max(), -1), (xstd::div_t{-limits::max(), 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_div(limits::max(), -1), (xstd::div_t{-limits::max(), 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(limits::max(), -1), (xstd::div_t{-limits::max(), 0}));
-}
-
-BOOST_AUTO_TEST_CASE(FlooredDiv)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(+8, +3), (xstd::div_t{+2, +2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(+8, -3), (xstd::div_t{-3, -1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-8, +3), (xstd::div_t{-3, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-8, -3), (xstd::div_t{+2, -2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(+1, +2), (xstd::div_t{0, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(+1, -2), (xstd::div_t{-1, -1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-1, +2), (xstd::div_t{-1, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_div(-1, -2), (xstd::div_t{0, -1}));
-}
-
-// ldiv/lldiv/imaxdiv (and their euclidean_/floored_ counterparts) run the
-// exact same algorithm as div, just parameterized by width; (-8, +3) and
-// each type's MIN boundary are enough to confirm the width plumbing itself,
-// since correctness of the algorithm is already covered above for int.
-BOOST_AUTO_TEST_CASE(Ldiv)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::ldiv(-8L, +3L), (xstd::ldiv_t{-2L, -2L}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_ldiv(-8L, +3L), (xstd::ldiv_t{-3L, +1L}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_ldiv(-8L, +3L), (xstd::ldiv_t{-3L, +1L}));
-
-        // Negative denom alongside a negative remainder: the only input
-        // shape not already hit above, needed to cover euclidean_ldiv's
-        // (denom > 0 ? ... : ...) branch.
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::ldiv(-8L, -3L), (xstd::ldiv_t{2L, -2L}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_ldiv(-8L, -3L), (xstd::ldiv_t{3L, 1L}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_ldiv(-8L, -3L), (xstd::ldiv_t{2L, -2L}));
-
-        using limits = std::numeric_limits<long>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::ldiv(limits::min(), +1L), (xstd::ldiv_t{limits::min(), 0L}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_ldiv(limits::min(), +1L), (xstd::ldiv_t{limits::min(), 0L}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_ldiv(limits::min(), +1L), (xstd::ldiv_t{limits::min(), 0L}));
-}
-
-BOOST_AUTO_TEST_CASE(Lldiv)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::lldiv(-8LL, +3LL), (xstd::lldiv_t{-2LL, -2LL}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_lldiv(-8LL, +3LL), (xstd::lldiv_t{-3LL, +1LL}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_lldiv(-8LL, +3LL), (xstd::lldiv_t{-3LL, +1LL}));
-
-        // Negative denom alongside a negative remainder: the only input
-        // shape not already hit above, needed to cover euclidean_lldiv's
-        // (denom > 0 ? ... : ...) branch.
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::lldiv(-8LL, -3LL), (xstd::lldiv_t{2LL, -2LL}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_lldiv(-8LL, -3LL), (xstd::lldiv_t{3LL, 1LL}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_lldiv(-8LL, -3LL), (xstd::lldiv_t{2LL, -2LL}));
-
-        using limits = std::numeric_limits<long long>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::lldiv(limits::min(), +1LL), (xstd::lldiv_t{limits::min(), 0LL}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_lldiv(limits::min(), +1LL), (xstd::lldiv_t{limits::min(), 0LL}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_lldiv(limits::min(), +1LL), (xstd::lldiv_t{limits::min(), 0LL}));
-}
-
-BOOST_AUTO_TEST_CASE(Imaxdiv)
-{
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::imaxdiv(-8, +3), (xstd::imaxdiv_t{-2, -2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_imaxdiv(-8, +3), (xstd::imaxdiv_t{-3, +1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_imaxdiv(-8, +3), (xstd::imaxdiv_t{-3, +1}));
-
-        // Negative denom alongside a negative remainder: the only input
-        // shape not already hit above, needed to cover euclidean_imaxdiv's
-        // (denom > 0 ? ... : ...) branch.
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::imaxdiv(-8, -3), (xstd::imaxdiv_t{2, -2}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_imaxdiv(-8, -3), (xstd::imaxdiv_t{3, 1}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_imaxdiv(-8, -3), (xstd::imaxdiv_t{2, -2}));
-
-        using limits = std::numeric_limits<std::intmax_t>;
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::imaxdiv(limits::min(), 1), (xstd::imaxdiv_t{limits::min(), 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::euclidean_imaxdiv(limits::min(), 1), (xstd::imaxdiv_t{limits::min(), 0}));
-        XSTD_CONSTEXPR_CHECK_EQUAL(xstd::floored_imaxdiv(limits::min(), 1), (xstd::imaxdiv_t{limits::min(), 0}));
-}
-
-BOOST_AUTO_TEST_CASE(Formatter)
-{
-        BOOST_CHECK_EQUAL(std::format("{}", xstd::div_t{1, -2}), "(1, -2)");
-        BOOST_CHECK_EQUAL(std::format("{}", xstd::ldiv_t{1L, -2L}), "(1, -2)");
-        BOOST_CHECK_EQUAL(std::format("{}", xstd::lldiv_t{1LL, -2LL}), "(1, -2)");
-        BOOST_CHECK_EQUAL(std::format("{}", xstd::imaxdiv_t{1, -2}), "(1, -2)");
-}
-
-BOOST_AUTO_TEST_CASE(StreamInsertion)
-{
-        std::ostringstream oss;
-        oss << xstd::div_t{1, -2};
-        BOOST_CHECK_EQUAL(oss.str(), "(1, -2)");
-
-        std::ostringstream loss;
-        loss << xstd::ldiv_t{1L, -2L};
-        BOOST_CHECK_EQUAL(loss.str(), "(1, -2)");
-
-        std::ostringstream lloss;
-        lloss << xstd::lldiv_t{1LL, -2LL};
-        BOOST_CHECK_EQUAL(lloss.str(), "(1, -2)");
-
-        std::ostringstream imaxoss;
-        imaxoss << xstd::imaxdiv_t{1, -2};
-        BOOST_CHECK_EQUAL(imaxoss.str(), "(1, -2)");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Motivation

The `cstdlib` header declared each of `abs`, `uabs`, `sign`, `div`, `euclidean_div`, `floored_div` and `div_t` four times over, at `int` / `long` / `long long` / `intmax_t`, mirroring how C's own `cstdlib` and `cinttypes` name theirs. That is 20-odd near-identical entities built from the same three lines, and a naming scheme with no name at all for the two narrowest signed widths.

## What changed

Each family becomes a single entity constrained to `std::signed_integral`. The header goes from 360 to 204 lines while covering strictly more types.

The exact-width types come for free: `int8_t` / `int16_t` / `int32_t` / `int64_t` are aliases of the built-in types the template already covers. The `imax`-prefixed names are no longer needed either — they existed only to dodge a platform-dependent overload collision between `long` and `intmax_t`, and one template has no overload set to collide with.

Three deliberate behavior changes:

- **The result type is the argument type, not the promoted type.** `abs` of an `int16_t` is an `int16_t` and takes `int16_t`'s precondition, where a call to the old non-template `abs(int)` promoted and was incidentally in contract for `INT16_MIN`. The old behavior is still spelled `abs(+x)`, or `abs` with an explicit `int` template argument.
- **Two-argument calls deduce one `T` from both arguments**, so `div(8, 3L)` is a deduction failure instead of a silent conversion. An explicit `long` template argument says which width the division happens at.
- **The identity check moved to where it means something.** See below.

`div_t` becomes a class template with an explicit deduction guide, so `div_t{quot, rem}` reads the same at the call site, and its `std::formatter` becomes a partial specialization. Side benefit: the formatter body is instantiated at the point of use, so *including* this header no longer requires a standard library with tuple formatting — only formatting an `xstd::div_t` does.

## The back-multiplication check, and what removing it exposed

`numer == denom * q + r` was previously asserted only by `div`, on the reasoning that `long long` holds the product of *any* two `int`s while nothing portable is wider than `intmax_t`. Two corrections came out of reviewing that:

- **Truncated division needs no widening at all.** `denom * qT` is exactly `numer - rT`, and `rT` carries `numer`'s sign, so the product lies between `0` and `numer` inclusive and is representable wherever `numer` is. `div` now asserts the identity in `T` itself, unconditionally — which gives the check at `intmax_t` width, where `imaxdiv` never had it.
- **For the two adjusted conventions the identity is a tautology.** Both compute `q' = qT - I` and `r' = rT + I * denom`, so `denom * q' + r' = denom * qT + rT`, which `div` has already checked. Asserting it again could only fire where `div`'s own assert had already fired — and, since the adjusted product genuinely can exceed `T`, restating it would have cost an `intmax_t` widening plus a `sizeof`-based gate. Both asserts and that machinery are gone.

Removing them exposed a **pre-existing overflow**, present on `main` too: `euclidean_div` selects `I == -1` when the truncated remainder and `denom` are both negative, and `denom == MIN` is *in contract*, so `I * denom` forms `-MIN`.

```
euclidean_div(-1, INT_MIN)
  UBSan: signed integer overflow: -1 * -2147483648 cannot be represented in type 'int'
```

Nothing caught it because no test used `denom == MIN` with a *negative* remainder, and below `int` the integer promotion evaluates it in `int` and hides it. Fixed by adjusting the remainder with an add or a subtract of `denom` chosen by its sign, never forming `-denom`, plus the missing input in `BoundaryDivisions` — which, being a constant expression, catches it at compile time as well as under a sanitizer.

`floored_div`'s `I` is two-valued, so multiplying `denom` by it was a select written the long way round; it is now spelled as a select. Measured at `-O2` with the function held out of line, GCC drops 29 → 24 instructions for `int32_t` and 27 → 22 for `int64_t`; Clang is unchanged, since it already canonicalizes a multiply by 0 or 1. `euclidean_div` keeps its `I`, whose quotient adjustment is genuinely three-valued.

## Tests

The four exact-width types run through `BOOST_AUTO_TEST_CASE_TEMPLATE` rather than each case being repeated per width; the suite goes from 15 to 49 test cases. New cases cover the constraint itself — unsigned, `bool`, floating-point and mixed-width calls are rejected, and the return types are the argument types — plus CTAD on `div_t`, and each width's `MIN` boundary in `uabs` and all three division conventions.

A separate `BuiltInWidths` battery covers the `int` / `long` / `long long` / `intmax_t` ladder, since which built-in type each exact-width alias names is platform-dependent: on LP64 `long long` would otherwise never be instantiated, on LLP64 `long` wouldn't. It exercises both arms of every conditional rather than calling each function once — a single call leaves the remainder adjustments half-covered and leaves `div_t`'s formatter and `operator<<` instantiated but never executed, since those only run when an assertion fails.

## Why 128-bit integers are not covered

The obvious next width, and the one this design would otherwise extend to for free. Excluded for reasons all external to xstd, each verified against GCC 13 and Clang 18:

- `std::integral` is not satisfied by `__int128` on libstdc++ outside GNU dialect mode, and the project sets `CMAKE_CXX_EXTENSIONS OFF` on purpose. libc++ answers differently, so even the concept check isn't portable.
- `std::make_unsigned_t` is a hard error rather than a substitution failure for it on libstdc++ in that mode, so `uabs`'s return type couldn't be spelled with it.
- GCC's `-pedantic-errors`, which the test targets enable, rejects naming `__int128` at all.
- MSVC has no 128-bit integer type.

Supporting it would mean an xstd-local `signed_integral` concept, an xstd-local `make_unsigned`, and a test TU exempted from the project's own conformance flags — three carve-outs from the strict-conformance policy for one width. `doc/design.md` records this; should any constraint lift, it is a one-line change to the constraint, which is the property the four-overload design did not have.

## Docs

`README.md` and `doc/design.md` are rewritten for the new shape, including a new "Width and constraints" section, the 128-bit rationale, and why `euclidean_div` adds or subtracts `denom` instead of scaling it. The `clang-tidy` and `codeql` workflow comments counting `assert`s across the headers are updated (49 → 14).

No workflow code snippets needed changes: all of them call `euclidean_div` or `floored_div` at `int`, which compiles identically.

## Verification

On GCC 13 and Clang 18 locally: full suite in Debug, in `-DNDEBUG -O2`, and under `-fsanitize=undefined,address,signed-integer-overflow -fno-sanitize-recover=all`; clean under the project's own `-Wall -Wextra -Wconversion -Wsign-conversion -Werror` (GCC) and `-Weverything -Werror` (Clang) sets; header self-sufficiency TU compiles; `clang-tidy` and `clang-format` clean. `gcovr` under the coverage workflow's own flags and thresholds reports 100% of lines, functions and branches for the header.

Beyond the suite, an exhaustive sweep of every in-contract pair for `int8_t` (65279) and `int16_t` (4294901759) through the real functions under UBSan, checking the identity and each convention's remainder rule in exact arithmetic.

Two things could not run locally: the `Formatter` case and anything reaching `std::format` on a `div_t`, because libstdc++ 13 has no tuple formatter (P2286 landed in libstdc++ 15); and `-Wnrvo`, which Clang 21+ includes in `-Weverything` and local Clang 18 does not have. Both are covered by CI.
