### PR TITLE
Deduce the trait-returning signatures, spell out the rest

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,6 @@ Checks: >
   readability-*,
   -misc-include-cleaner,
   -misc-non-private-member-variables-in-classes,
-  -modernize-use-trailing-return-type,
   -readability-avoid-nested-conditional-operator,
   -readability-identifier-length,
   -readability-named-parameter,

--- a/doc/design.md
+++ b/doc/design.md
@@ -137,6 +137,45 @@ not. Rust names the same operation
 [`unsigned_abs`](https://doc.rust-lang.org/std/primitive.i32.html#method.unsigned_abs)
 for the same reason; C++ has no equivalent, standard or in Boost.Math.
 
+### Why some return types are deduced and the rest are spelled out
+
+Every function in `<xstd/cstdlib.hpp>` with a return type worth naming spells
+it out as a trailing return type - except `uabs`, which deduces its own.
+`xstd::to_underlying` deduces for the same reason. This is not a style
+inconsistency; it is
+[CWG2369](https://cplusplus.github.io/CWG/issues/2369.html), "ordering between
+constraints and substitution".
+
+A constrained function template's associated constraints should be checked
+*before* the deduced arguments are substituted into the rest of the
+declaration. GCC does this. Clang did not until
+[Clang 21](https://github.com/llvm/llvm-project/pull/122423), which substitutes
+first, so a return type that instantiates a trait gets instantiated even for
+arguments the constraint would have rejected:
+
+    template<std::signed_integral T>
+    constexpr auto uabs(T x) noexcept -> std::make_unsigned_t<T>;
+
+    static_assert(!has_uabs<double>);   // hard error on Clang < 21
+
+`std::make_unsigned_t<double>` is ill-formed, not a substitution failure, so
+`uabs(1.0)` inside a requires-expression stops the compile instead of
+evaluating to `false`. `abs` and `sign` are immune because their return types
+(`T` and `int`) instantiate nothing; so are `div`, `euclidean_div` and
+`floored_div`, because forming `div_t<double>` fails the class template's own
+constraint in the immediate context, which *is* a substitution failure.
+
+Deducing `uabs`'s return type moves the trait from the signature into the body,
+where `std::signed_integral` has already rejected the argument. The rule for
+this library: spell the return type out unless it instantiates a trait over a
+template parameter, in which case deduce it.
+
+This is worth revisiting rather than keeping forever. The `Clang` and
+`Clang libc++` legs already run Clang 22 and newer, but `Clang-CL` uses
+whichever LLVM Visual Studio bundles - 19.1.5 for VS 2022 and 20.1.8 for
+VS 2026 - both of which predate the fix. When the oldest supported Clang is 21
+or later, both return types can be spelled out and this note deleted.
+
 ### The division contracts' back-multiplication check
 
 `numer == denom * q + r` is the strongest self-check a division function can
@@ -176,7 +215,20 @@ chosen by its sign, which never forms `-denom`:
     qE = denom > 0 ? qT - 1 : qT + 1
     rE = denom > 0 ? rT + denom : rT - denom
 
-`floored_div` needs no such care: it only ever scales `denom` by `0` or `1`.
+Both lines select a whole expression rather than adding a delta, because the
+delta they would have to add is `|denom|` - a value that does not exist in `T`
+when `denom == MIN`.
+
+`floored_div` needs no such care. Its delta is `denom` itself, which is
+representable by definition, so `I` is only ever `0` or `1` and both lines can
+add a conditional delta instead:
+
+    qF = qT - (adjust ? 1 : 0)
+    rF = rT + (adjust ? denom : 0)
+
+where `adjust` is `sign(rT) == -sign(denom)`. The two conventions therefore
+look deliberately different: each spells its adjustment in the form its own
+representability constraints allow.
 
 ### `xstd::div_t` formatting
 

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -78,7 +78,7 @@ template<std::signed_integral T>
         // exactly the value the wider unsigned types get directly. The zero
         // needs no type of its own: the usual arithmetic conversions give the
         // subtraction the same type either way.
-        return x < 0 ? static_cast<U>(0 - u) : u;
+        return static_cast<U>(x < 0 ? 0 - u : u);
 }
 
 // not part of <cstdlib>, but kept to the same shape as abs/uabs above. The

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -47,7 +47,7 @@ template<std::signed_integral T>
         -> T
 {
         assert(x != std::numeric_limits<T>::min()); // -x would overflow
-        return x < 0 ? static_cast<T>(-x) : x;
+        return static_cast<T>(x < 0 ? -x : x);
 }
 
 // The total counterpart of abs: same |x|, but returning the unsigned type, so

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -143,7 +143,7 @@ template<std::signed_integral T>
         -> div_t<T>
 {
         assert(denom != 0);
-        auto const divT = div(numer, denom);
+        auto const [qT, rT] = div(numer, denom);
         // A negative truncated remainder is moved up by one |denom|, with the
         // quotient compensated in the matching direction. Both lines select a
         // whole expression rather than adding a delta, because the delta here
@@ -152,9 +152,9 @@ template<std::signed_integral T>
         // it as an add or a subtract of denom chosen by denom's sign keeps
         // every intermediate in range. (floored_div below adjusts by denom
         // itself, which is always representable, so it can add a delta.)
-        auto const adjust = divT.rem < 0;
-        auto const qE = static_cast<T>(adjust ? (denom > 0 ? divT.quot - 1 : divT.quot + 1) : divT.quot);
-        auto const rE = static_cast<T>(adjust ? (denom > 0 ? divT.rem + denom : divT.rem - denom) : divT.rem);
+        auto const adjust = rT < 0;
+        auto const qE = static_cast<T>(adjust ? (denom > 0 ? qT - 1 : qT + 1) : qT);
+        auto const rE = static_cast<T>(adjust ? (denom > 0 ? rT + denom : rT - denom) : rT);
         assert(uabs(rE) < uabs(denom));
         assert(sign(rE) >= 0);
         return {.quot = qE, .rem = rE};
@@ -169,16 +169,16 @@ template<std::signed_integral T>
         -> div_t<T>
 {
         assert(denom != 0);
-        auto const divT = div(numer, denom);
+        auto const [qT, rT] = div(numer, denom);
         // The same adjustment as euclidean_div above, but two-valued rather
         // than three: a remainder whose sign differs from denom's is moved one
         // denom in denom's direction, and the quotient compensated. The delta
         // is denom itself rather than |denom|, and denom is by definition
         // representable, so both lines can add a conditional delta instead of
         // selecting a whole expression. Neither zero needs a type of its own.
-        auto const adjust = sign(divT.rem) == -sign(denom);
-        auto const qF = static_cast<T>(divT.quot - (adjust ? 1 : 0));
-        auto const rF = static_cast<T>(divT.rem + (adjust ? denom : 0));
+        auto const adjust = sign(rT) == -sign(denom);
+        auto const qF = static_cast<T>(qT - (adjust ? 1 : 0));
+        auto const rF = static_cast<T>(rT + (adjust ? denom : 0));
         assert(uabs(rF) < uabs(denom));
         assert(rF == 0 || sign(rF) == sign(denom));
         return {.quot = qF, .rem = rF};

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -43,7 +43,8 @@ namespace xstd {
 // constexpr version of <cstdlib>'s abs/labs/llabs and <cinttypes>'s imaxabs
 // (P0533), generalized to one signed-only template.
 template<std::signed_integral T>
-[[nodiscard]] constexpr T abs(T x) noexcept
+[[nodiscard]] constexpr auto abs(T x) noexcept
+        -> T
 {
         assert(x != std::numeric_limits<T>::min()); // -x would overflow
         return x < 0 ? static_cast<T>(-x) : x;
@@ -55,23 +56,37 @@ template<std::signed_integral T>
 // unsigned wraparound, which is well-defined, rather than by -x on a signed
 // MIN, which is not, or by widening to a bigger signed type, which has none
 // to widen to at the widest end.
+//
+// The return type is deduced rather than spelled std::make_unsigned_t<T>,
+// which is the one signature in this header where that choice is load-bearing
+// rather than cosmetic. Clang before 21 does not implement CWG2369: it
+// substitutes the deduced arguments into the function type before checking the
+// constraint, so a spelled-out return type instantiates make_unsigned_t<double>
+// for uabs(1.0) - a hard error rather than a substitution failure, which makes
+// the call ill-formed inside a requires-expression instead of merely false.
+// Deducing keeps the trait out of the signature, so std::signed_integral gets
+// to reject the argument first. Every other return type here (T, int, bool,
+// div_t<T>) instantiates no trait and is spelled out. See doc/design.md.
 template<std::signed_integral T>
-[[nodiscard]] constexpr std::make_unsigned_t<T> uabs(T x) noexcept
+[[nodiscard]] constexpr auto uabs(T x) noexcept
 {
         using U = std::make_unsigned_t<T>;
         auto const u = static_cast<U>(x);
         // The cast back to U is what makes this wraparound rather than
-        // promotion: for types narrower than int, U{0} - u is evaluated in
-        // int and is negative, and converting that back to U reduces it mod
-        // 2^N - exactly the value the wider unsigned types get directly.
-        return x < 0 ? static_cast<U>(U{0} - u) : u;
+        // promotion: for types narrower than int, 0 - u is evaluated in int
+        // and is negative, and converting that back to U reduces it mod 2^N -
+        // exactly the value the wider unsigned types get directly. The zero
+        // needs no type of its own: the usual arithmetic conversions give the
+        // subtraction the same type either way.
+        return x < 0 ? static_cast<U>(0 - u) : u;
 }
 
 // not part of <cstdlib>, but kept to the same shape as abs/uabs above. The
 // result is a plain int at every width: a sign is a three-valued quantity,
 // not a number in T's range.
 template<std::signed_integral T>
-[[nodiscard]] constexpr int sign(T x) noexcept
+[[nodiscard]] constexpr auto sign(T x) noexcept
+        -> int
 {
         return static_cast<int>(0 < x) - static_cast<int>(x < 0);
 }
@@ -80,7 +95,7 @@ template<std::signed_integral T>
 struct div_t
 {
         T quot, rem;
-        [[nodiscard]] friend constexpr bool operator==(div_t const&, div_t const&) noexcept = default;
+        [[nodiscard]] friend constexpr auto operator==(div_t const&, div_t const&) noexcept -> bool = default;
 };
 
 // Aggregate class template argument deduction would already deduce this, but
@@ -100,7 +115,8 @@ div_t(T, T) -> div_t<T>;
 // remainder: Ruby, Scheme
 // mod: Fortran, OCaml
 template<std::signed_integral T>
-[[nodiscard]] constexpr div_t<T> div(T numer, T denom) noexcept
+[[nodiscard]] constexpr auto div(T numer, T denom) noexcept
+        -> div_t<T>
 {
         assert(denom != 0);
         assert(!(numer == std::numeric_limits<T>::min() && denom == -1));
@@ -123,20 +139,22 @@ template<std::signed_integral T>
 // mod: Maple, Pascal
 // modulo: Scheme
 template<std::signed_integral T>
-[[nodiscard]] constexpr div_t<T> euclidean_div(T numer, T denom) noexcept
+[[nodiscard]] constexpr auto euclidean_div(T numer, T denom) noexcept
+        -> div_t<T>
 {
         assert(denom != 0);
         auto const divT = div(numer, denom);
         // A negative truncated remainder is moved up by one |denom|, with the
-        // quotient compensated in the matching direction. The remainder's
-        // adjustment is spelled as an add or a subtract of denom rather than
-        // as rem + I * denom: denom == MIN is in contract here and -MIN is not
-        // representable, so forming I * denom with I == -1 would overflow.
-        // (floored_div below only ever scales denom by 0 or 1, so it has no
-        // such case.)
-        auto const I = divT.rem >= 0 ? T{0} : (denom > 0 ? T{1} : T{-1});
-        auto const qE = static_cast<T>(divT.quot - I);
-        auto const rE = static_cast<T>(I == 0 ? divT.rem : (denom > 0 ? divT.rem + denom : divT.rem - denom));
+        // quotient compensated in the matching direction. Both lines select a
+        // whole expression rather than adding a delta, because the delta here
+        // is |denom|: denom == MIN is in contract and -MIN is not
+        // representable, so the value can never be formed on its own. Spelling
+        // it as an add or a subtract of denom chosen by denom's sign keeps
+        // every intermediate in range. (floored_div below adjusts by denom
+        // itself, which is always representable, so it can add a delta.)
+        auto const adjust = divT.rem < 0;
+        auto const qE = static_cast<T>(adjust ? (denom > 0 ? divT.quot - 1 : divT.quot + 1) : divT.quot);
+        auto const rE = static_cast<T>(adjust ? (denom > 0 ? divT.rem + denom : divT.rem - denom) : divT.rem);
         assert(uabs(rE) < uabs(denom));
         assert(sign(rE) >= 0);
         return {.quot = qE, .rem = rE};
@@ -147,18 +165,20 @@ template<std::signed_integral T>
 // mod: Ada, Clojure, Haskell, Julia, Lisp, ML, Prolog
 // modulo: Fortran, Ruby
 template<std::signed_integral T>
-[[nodiscard]] constexpr div_t<T> floored_div(T numer, T denom) noexcept
+[[nodiscard]] constexpr auto floored_div(T numer, T denom) noexcept
+        -> div_t<T>
 {
         assert(denom != 0);
         auto const divT = div(numer, denom);
         // The same adjustment as euclidean_div above, but two-valued rather
         // than three: a remainder whose sign differs from denom's is moved one
-        // denom in denom's direction, and the quotient compensated. So no I to
-        // scale denom by - that factor could only ever be 0 or 1, which makes
-        // the multiplication a select written the long way round.
+        // denom in denom's direction, and the quotient compensated. The delta
+        // is denom itself rather than |denom|, and denom is by definition
+        // representable, so both lines can add a conditional delta instead of
+        // selecting a whole expression. Neither zero needs a type of its own.
         auto const adjust = sign(divT.rem) == -sign(denom);
-        auto const qF = static_cast<T>(adjust ? divT.quot - 1 : divT.quot);
-        auto const rF = static_cast<T>(adjust ? divT.rem + denom : divT.rem);
+        auto const qF = static_cast<T>(divT.quot - (adjust ? 1 : 0));
+        auto const rF = static_cast<T>(divT.rem + (adjust ? denom : 0));
         assert(uabs(rF) < uabs(denom));
         assert(rF == 0 || sign(rF) == sign(denom));
         return {.quot = qF, .rem = rF};
@@ -194,7 +214,8 @@ namespace xstd {
 // these types via std::format/std::print directly rather than through
 // operator<<.
 template<std::signed_integral T>
-auto& operator<<(std::ostream& ostr, div_t<T> const& d)
+auto operator<<(std::ostream& ostr, div_t<T> const& d)
+        -> std::ostream&
 {
         return ostr << std::format("{}", d);
 }

--- a/include/xstd/utility.hpp
+++ b/include/xstd/utility.hpp
@@ -16,9 +16,16 @@ namespace xstd {
 
 // std::to_underlying (P1682R3) only takes a plain enum value; this overload
 // preserves compile-time-constant-ness for an integral_constant-wrapped enum.
+// The return type is deduced rather than spelled out for the same reason
+// xstd::uabs's is: it would mention std::underlying_type_t<Enum>, and Clang
+// before 21 (no CWG2369) substitutes the return type before checking the
+// constraint, turning to_underlying(non_enum) in a requires-expression from
+// false into a hard error. The requires-clause sits in the template head so it
+// reads next to the parameter it constrains; is_enum_v is a variable template
+// rather than a concept, so it cannot become a type-constraint on Enum.
 template<class Enum, Enum N>
-[[nodiscard]] constexpr auto to_underlying(std::integral_constant<Enum, N>) noexcept
         requires std::is_enum_v<Enum>
+[[nodiscard]] constexpr auto to_underlying(std::integral_constant<Enum, N>) noexcept
 {
         return std::integral_constant<std::underlying_type_t<Enum>, std::to_underlying(N)>();
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,9 +84,12 @@ foreach(h ${public_headers})
     string(REPLACE "/" "." header_test_id ${h})
     string(REGEX REPLACE "[.]hpp$" "" header_test_id ${header_test_id})
     set(header_test_source ${CMAKE_CURRENT_BINARY_DIR}/header_self_sufficiency/${header_test_id}.cpp)
+    # main is spelled with a trailing return type because these generated
+    # sources are also what clang-tidy runs over, and modernize-use-trailing-
+    # return-type (enabled, like the rest of modernize-*) flags "int main()".
     file(
         WRITE ${header_test_source}
-        "#include <${h}>\nint main() {}\n"
+        "#include <${h}>\nauto main() -> int {}\n"
     )
 
     add_executable(header.${header_test_id} ${header_test_source})

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -76,6 +76,19 @@ BOOST_AUTO_TEST_CASE(NonSignedIntegralArgumentsAreRejected)
         static_assert(!has_abs<double>);
         static_assert(!has_sign<char*>);
 
+        // uabs is the only one of the three whose return type is computed by a
+        // trait, so it is the only one where rejecting a non-integral argument
+        // depends on the trait never being instantiated. Clang before 21 does
+        // not implement CWG2369 and substitutes the return type before checking
+        // the constraint, so spelling std::make_unsigned_t<T> in the signature
+        // makes the double and char* cases a hard error rather than a
+        // substitution failure - these two stop compiling instead of being
+        // false. The deduced return type in the header is what keeps them
+        // compiling; see doc/design.md.
+        static_assert(!has_uabs<bool>);
+        static_assert(!has_uabs<double>);
+        static_assert(!has_uabs<char*>);
+
         // Both parameters deduce the same T, so a mixed-width call is a
         // deduction failure rather than a silent conversion of one operand.
         static_assert(!has_div<std::int32_t, std::int64_t>);


### PR DESCRIPTION
Started as a one-line question about `floored_div`'s quotient adjustment and turned up a latent SFINAE bug in `uabs`. Tracking issue for the underlying compiler gap: #109.

## The bug

[CWG2369](https://cplusplus.github.io/CWG/issues/2369.html) requires a constrained function template's constraints to be checked before the deduced arguments are substituted into the rest of the declaration. GCC does this; Clang did not until [Clang 21](https://github.com/llvm/llvm-project/pull/122423). Against the header as it stands on `main`:

```cpp
template<class T> concept has_uabs = requires (T x) { xstd::uabs(x); };
static_assert(!has_uabs<double>);
```
```
g++ 13.3   : ok (substitution failure)
clang++ 18 : error: implicit instantiation of undefined template 'std::__make_unsigned_selector<double>'
```

`uabs` is the only function in the library whose return type is computed by a trait, and the only one with no non-integral negative test — `abs` and `sign` have `!has_abs<double>` / `!has_sign<char*>` but return `T` and `int`, instantiating nothing. The gap in coverage lines up exactly with the gap in the code, which is why CI is green today.

`Clang` and `Clang libc++` run Clang 22+, so they are unaffected. `Clang-CL` uses whichever LLVM Visual Studio bundles — 19.1.5 and 20.1.8 — both of which predate the fix.

## Changes

**`uabs` and `to_underlying` deduce their return types**, moving the trait out of the signature and into the body where the constraint has already rejected the argument. **Everything else in `<xstd/cstdlib.hpp>` gains an explicit trailing return type**: `T`, `int`, `bool` and `div_t<T>` instantiate no trait, and `div_t<double>` fails the class template's own constraint in the immediate context, which is a substitution failure already. `to_underlying`'s requires-clause also moves into the template head, next to the parameter it constrains.

**`floored_div` and `euclidean_div` now each spell their adjustment in the form their own representability constraints allow.** `floored_div`'s delta is `denom`, always representable, so both lines add a conditional delta. `euclidean_div`'s delta is `|denom|`, which does not exist when `denom == MIN`, so both of its lines select whole expressions — and its `I` disappears in favour of the same two-valued `adjust` flag. `doc/design.md`'s derivation now matches the code verbatim rather than describing an `I` the reader has to reconstruct.

**`uabs` writes the wraparound as `0 - u`** rather than `U{0} - u`. The zero needs no type: below `int` both operands promote to `int` either way, and at `int` and wider the literal converts to `U` either way.

**`abs` and `uabs` cast once, around the whole conditional**, instead of inside one branch. They were the last two places doing the latter; `div`, `euclidean_div` and `floored_div` already wrapped the whole expression. All six computed values in the header now use exactly one cast.

**`euclidean_div` and `floored_div` destructure `div`'s result** — `auto const [qT, rT]` rather than `divT.quot` / `divT.rem`. The pair itself was never used, and `qT`/`rT` are what `div` already calls its own locals and what `doc/design.md` calls them throughout. Binding positionally is safe here in a way it would not be for `std::div_t`, whose members are specified only "in unspecified order": `xstd::div_t` is declared in this header, so the order is ours, and a future reorder is a compile error anyway — the `return {.quot = ..., .rem = ...}` statements use designated initializers, which C++20 requires in declaration order (`-Wreorder-init-list` under the `-Weverything -Werror` this project builds with).

**`modernize-use-trailing-return-type` is now enabled.** Nothing in `include/xstd` trips it once `cstdlib.hpp` is converted, so the suppression only left the door open for a leading return type to reappear unnoticed. The check also flags `int main()`, and the header self-sufficiency sources clang-tidy runs over are generated with one, so `test/CMakeLists.txt` now generates `auto main() -> int {}`.

**Two new assertions**, `!has_uabs<double>` and `!has_uabs<char*>`, which is what would catch a regression.

## Verification

- The new tests **fail to compile against the previous header on Clang 18** (2 hard errors) and **pass against this one** — the regression check is real, not decorative.
- Full `cstdlib` suite: 44 test cases, no errors. Full `utility` suite: 2 test cases, no errors. Locally the `Formatter` case is skipped because libstdc++ 13 has no tuple formatter — that gap is pre-existing and reproduces on the branch point unchanged; CI runs GCC 15/16/17.
- Both division rewrites checked exhaustively against their invariants (`n` over ±400, `d` over ±20, `int32_t` and `int64_t`): remainder sign rule, `|r| < |denom|`, and `denom * q + r == numer`. `abs` and `uabs` checked exhaustively at `int8_t`/`int16_t` and at the endpoints for the wider types.
- Return types unchanged at all four exact widths: `decltype(uabs(T{}))` is still `std::make_unsigned_t<T>`.
- Clean under the repo's own flags — g++ `-Wconversion -Wsign-conversion -Wsign-promo -pedantic-errors -Werror`, clang `-Weverything -Werror`, clang-tidy (0 findings), clang-format byte-stable.

### Performance: no measurable change

Benchmarked `int64_t`, 2²⁰ calls, best of 9, ns per call, branch point vs HEAD:

| | GCC before → after | Clang before → after |
|---|---|---|
| `euclidean_div`, mixed signs | 18.29 → 18.61 | 16.03 → 16.12 |
| `euclidean_div`, needs 64 bits | 18.19 → 18.23 | 18.37 → 18.03 |
| `floored_div`, mixed signs | 16.82 → 16.65 | 12.58 → 12.50 |
| `floored_div`, needs 64 bits | 16.76 → 16.69 | 11.48 → 11.43 |

Every pair is within run-to-run noise. Instruction counts do shift (GCC's `euclidean_div` drops 21 → 15 at `int64_t` because dropping `I` lets it emit two straight-line tails), but none of it is visible in time: these functions are dominated by `idiv` and, on sign-mixed input, by branch misprediction on the adjustment. With uniformly non-negative operands — where `adjust` never fires and predicts perfectly — `euclidean_div` costs the same as `div` itself, which is the clearest evidence that the adjustment arithmetic is not what anyone is paying for.

**This PR should be judged on readability and on the SFINAE fix, not on codegen.**

## Notes for review

- The `uabs` and `to_underlying` deductions are deliberate and commented as such — they will look like style inconsistencies otherwise. #109 tracks reverting them once the Clang floor reaches 21, and lists exactly what to delete.
- The two new `!has_uabs` assertions should stay even after that revert; they are the regression guard.