### PR TITLE
Add &lt;xstd/concepts.hpp&gt; with enumeration and specialization_of

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(
     BASE_DIRS include
     FILES
         include/xstd/array.hpp
+        include/xstd/concepts.hpp
         include/xstd/cstdlib.hpp
         include/xstd/type_traits.hpp
         include/xstd/utility.hpp

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ xstd is a header-only C++23 library for small standard-library extensions that c
 | Header                   | Additions          | Description | Reference |
 | :-----                   | :--------          | :---------- | :-------- |
 | `<xstd/array.hpp>`       | `array_from_types` | Create an `array` from a type list | none |
+| `<xstd/concepts.hpp>`    | `enumeration` <br> `specialization_of` | Is a type an enumeration type? <br> Constraint form of `is_specialization_of` | none <br> [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) |
 | `<xstd/cstdlib.hpp>`     | `sign` <br> `abs` <br> `uabs` <br> `div_t` <br> `div` <br> `euclidean_div` <br> `floored_div` | `constexpr`, any signed integral type <br> `constexpr`, any signed integral type <br> Total `\|x\|`, returning the unsigned type <br> `std::format` support, defaulted equality comparison <br> `constexpr`, any signed integral type <br> Euclidean division <br> Floored division | [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Rust `unsigned_abs`](https://doc.rust-lang.org/std/primitive.i32.html#method.unsigned_abs) (no C++ equivalent) <br> [p2286r8](https://wg21.link/p2286r8) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) |
 | `<xstd/type_traits.hpp>` | `is_specialization_of` <br> `is_integral_constant` <br> `tagged_empty` <br> `optional_type` | Is a type a class template specialization? <br> Is a type an `integral_constant`? <br> A tagged empty type <br> An optional type | [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) <br> none <br> none <br> none |
 | `<xstd/utility.hpp>`     | `to_underlying` <br> `aligned_size` | `std::integral_constant` overload <br> Round a size up to a multiple of an alignment | none <br> none |
@@ -154,6 +155,35 @@ static_assert(!xstd::is_specialization_of_v<int, std::complex>);
 ```
 
 `xstd::is_specialization_of` isn't fully general: its `Primary` parameter is constrained to `template<class...> class`, so it only accepts class templates whose parameters are all types. A template with a non-type parameter, like `std::array` (`template<class, size_t>`), doesn't just evaluate to `false` here - passing it as the second argument is a hard compile error, since its template template parameter kind doesn't match `template<class...> class`. See [doc/design.md](doc/design.md) for why.
+
+### Concepts
+
+`<concepts>` has `std::integral`, `std::signed_integral` and `std::floating_point`, but nothing for enums. `xstd::enumeration` fills that gap, so a template that wants an enum can say so in its template head instead of trailing a `requires std::is_enum_v<T>`:
+
+```cpp
+#include <xstd/concepts.hpp>
+
+enum class color : unsigned { red = 1 };
+
+template<xstd::enumeration Enum>
+constexpr auto is_red(Enum e) -> bool { return e == Enum::red; }
+
+static_assert(is_red(color::red));
+```
+
+`xstd::specialization_of` is the constraint spelling of `xstd::is_specialization_of`. It takes the type under test first, so partially applying it to a primary template gives a type-constraint:
+
+```cpp
+#include <complex>
+#include <xstd/concepts.hpp>
+
+template<xstd::specialization_of<std::complex> T>
+constexpr auto real_part(T z) { return z.real(); }
+
+static_assert(real_part(std::complex<double>(1.0, 2.0)) == 1.0);
+```
+
+It inherits the trait's `template<class...> class` restriction on `Primary`, including the hard error for a template with a non-type parameter.
 
 ## Project layout
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -266,6 +266,63 @@ fully general version - one that also handles non-type template parameters
 - isn't expressible with today's template template parameter matching
 rules. C++26 reflection may enable one.
 
+### `<xstd/concepts.hpp>`, and when a trait also gets a concept spelling
+
+`<concepts>` names the built-in numeric categories - `integral`,
+`signed_integral`, `unsigned_integral`, `floating_point` - but stops there,
+so a template wanting an enum has no type-constraint to reach for and has to
+fall back on a requires-clause over `std::is_enum_v`. `xstd::enumeration` is
+that missing name, and it is what lets `xstd::to_underlying` put its
+constraint where it belongs:
+
+    template<enumeration Enum, Enum N>
+    constexpr auto to_underlying(std::integral_constant<Enum, N>) noexcept;
+
+This is deliberately *not* a second way to spell the same check. A
+type-constraint and a requires-clause in the template head are both
+associated constraints, checked at the same point, so swapping one for the
+other leaves the CWG2369 ordering discussed above untouched - the return type
+stays deduced for its own separate reason. What changes is only that the
+restriction reads next to the parameter it restricts.
+
+`xstd::specialization_of` is a different case: it is the constraint form of a
+trait that already exists, and it earns its place because the trait cannot
+serve that role. A concept can be partially applied in a type-constraint,
+
+    template<specialization_of<std::complex> T> void f(T);
+
+which is the form callers actually want, and which
+`is_specialization_of_v<T, std::complex>` has no way to produce. The rule
+this sets for the library: a trait gets a concept spelling when the concept
+enables a *use* the trait cannot, not merely so that both exist.
+
+Both are named as the noun the type satisfies rather than as `is_enum` /
+`is_specialization_of`, following how every concept in `<concepts>` reads.
+Beyond consistency, a concept sharing an unqualified name with the trait it
+wraps is ambiguous for anyone with using-directives for both namespaces,
+which for `enumeration` would have meant colliding with `std::is_enum`.
+
+### Why `is_integral_constant` does not constrain the wrapped type
+
+`std::integral_constant<T, v>` puts no constraint on `T`: anything usable as
+a non-type template parameter works, enums and pointers included. The
+obvious-looking tightening -
+
+    template<std::integral U, U N>
+    inline constexpr auto is_integral_constant_v<std::integral_constant<U, N>, U> = true;
+
+- would therefore be a narrowing rather than a clarification, and it would
+narrow away precisely the case the header is built around: `xstd::to_underlying`
+exists to accept `std::integral_constant<Enum, N>`, and the trait exists so
+generic code can detect that wrapping at all. Constraining `U` to
+`std::integral` would leave the trait blind to it.
+
+Without the constraint the trait is already exact - the primary template is
+`false`, and only `std::integral_constant<U, N>` matches the specialization -
+so there is nothing over-broad to tighten. The enum case is pinned by a test
+rather than left implicit, because every other check in that test uses `bool`
+or `int` and so would keep passing if someone made this change anyway.
+
 ## CI and toolchain support
 
 ### Compiler support policy

--- a/include/xstd/concepts.hpp
+++ b/include/xstd/concepts.hpp
@@ -1,0 +1,37 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_CONCEPTS_HPP
+#define XSTD_CONCEPTS_HPP
+
+#include <xstd/type_traits.hpp> // is_specialization_of_v
+#include <type_traits>          // is_enum_v
+
+namespace xstd {
+
+// <concepts> covers the built-in numeric categories - integral,
+// signed_integral, unsigned_integral, floating_point - but has nothing for
+// enums, so a template that wants one has to fall back on a requires-clause
+// over std::is_enum_v. Spelled as the noun the type satisfies rather than as
+// is_enum, because that is how every concept in <concepts> reads (integral,
+// destructible, regular), and because a concept sharing a name with the trait
+// it wraps would be ambiguous under using-directives for both namespaces.
+template<class T>
+concept enumeration = std::is_enum_v<T>;
+
+// The constraint spelling of xstd::is_specialization_of. The type under test
+// comes first so that a partial application names the primary template alone,
+// which is the form a type-constraint needs:
+//
+//     template<specialization_of<std::complex> T> void f(T);
+//
+// Primary carries the same template<class...> class restriction, and the same
+// hard error for a template with a non-type parameter, as the trait does.
+template<class T, template<class...> class Primary>
+concept specialization_of = is_specialization_of_v<T, Primary>;
+
+} // namespace xstd
+
+#endif // XSTD_CONCEPTS_HPP

--- a/include/xstd/utility.hpp
+++ b/include/xstd/utility.hpp
@@ -6,11 +6,12 @@
 #ifndef XSTD_UTILITY_HPP
 #define XSTD_UTILITY_HPP
 
-#include <cassert>     // assert
-#include <cstddef>     // size_t
-#include <limits>      // numeric_limits
-#include <type_traits> // integral_constant, is_enum_v, underlying_type_t
-#include <utility>     // to_underlying
+#include <xstd/concepts.hpp> // enumeration
+#include <cassert>           // assert
+#include <cstddef>           // size_t
+#include <limits>            // numeric_limits
+#include <type_traits>       // integral_constant, underlying_type_t
+#include <utility>           // to_underlying
 
 namespace xstd {
 
@@ -20,11 +21,11 @@ namespace xstd {
 // xstd::uabs's is: it would mention std::underlying_type_t<Enum>, and Clang
 // before 21 (no CWG2369) substitutes the return type before checking the
 // constraint, turning to_underlying(non_enum) in a requires-expression from
-// false into a hard error. The requires-clause sits in the template head so it
-// reads next to the parameter it constrains; is_enum_v is a variable template
-// rather than a concept, so it cannot become a type-constraint on Enum.
-template<class Enum, Enum N>
-        requires std::is_enum_v<Enum>
+// false into a hard error. The constraint is a type-constraint on Enum, which
+// reads next to the parameter it restricts and is checked at the same point a
+// requires-clause in the template head would be, so it leaves that ordering
+// unchanged.
+template<enumeration Enum, Enum N>
 [[nodiscard]] constexpr auto to_underlying(std::integral_constant<Enum, N>) noexcept
 {
         return std::integral_constant<std::underlying_type_t<Enum>, std::to_underlying(N)>();

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -1,0 +1,63 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <xstd/concepts.hpp>        // enumeration, specialization_of
+#include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK
+#include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
+#include <complex>                  // complex
+#include <tuple>                    // tuple
+
+using namespace xstd;
+
+BOOST_AUTO_TEST_SUITE(Concepts)
+
+enum unscoped { u0 };
+enum class scoped : unsigned { s0 };
+struct not_an_enum {};
+
+BOOST_AUTO_TEST_CASE(Enumeration)
+{
+        XSTD_CONSTEXPR_CHECK(enumeration<unscoped>);
+        XSTD_CONSTEXPR_CHECK(enumeration<scoped>);
+
+        XSTD_CONSTEXPR_CHECK(!enumeration<int>);
+        XSTD_CONSTEXPR_CHECK(!enumeration<bool>);
+        XSTD_CONSTEXPR_CHECK(!enumeration<not_an_enum>);
+        XSTD_CONSTEXPR_CHECK(!enumeration<scoped&>);
+        XSTD_CONSTEXPR_CHECK(!enumeration<scoped*>);
+        XSTD_CONSTEXPR_CHECK(!enumeration<void>);
+}
+
+// the partial application a type-constraint needs: the primary template alone
+template<specialization_of<std::complex> T>
+constexpr auto as_complex(T z) noexcept -> T
+{
+        return z;
+}
+
+template<class T>
+concept has_as_complex = requires (T t) { as_complex(t); };
+
+BOOST_AUTO_TEST_CASE(SpecializationOf)
+{
+        XSTD_CONSTEXPR_CHECK((specialization_of<std::complex<int>, std::complex>));
+        XSTD_CONSTEXPR_CHECK((specialization_of<std::tuple<int, char>, std::tuple>));
+        XSTD_CONSTEXPR_CHECK((specialization_of<std::tuple<>, std::tuple>));
+
+        XSTD_CONSTEXPR_CHECK((!specialization_of<int, std::complex>));
+        XSTD_CONSTEXPR_CHECK((!specialization_of<std::tuple<int>, std::complex>));
+        XSTD_CONSTEXPR_CHECK((!specialization_of<std::complex<int>&, std::complex>));
+
+        // the concept agrees with the trait it is spelled over
+        XSTD_CONSTEXPR_CHECK((specialization_of<std::complex<int>, std::complex> == is_specialization_of_v<std::complex<int>, std::complex>));
+        XSTD_CONSTEXPR_CHECK((specialization_of<int, std::complex> == is_specialization_of_v<int, std::complex>));
+
+        // used as a type-constraint, it constrains rather than hard-errors
+        XSTD_CONSTEXPR_CHECK(has_as_complex<std::complex<int>>);
+        XSTD_CONSTEXPR_CHECK(!has_as_complex<int>);
+        XSTD_CONSTEXPR_CHECK(as_complex(std::complex<int>(1, 2)) == std::complex<int>(1, 2));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -4,7 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <xstd/concepts.hpp>        // enumeration, specialization_of
-#include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK
+#include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK, XSTD_CONSTEXPR_CHECK_EQUAL
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
 #include <complex>                  // complex
 #include <tuple>                    // tuple
@@ -41,6 +41,29 @@ constexpr auto as_complex(T z) noexcept -> T
 template<class T>
 concept has_as_complex = requires (T t) { as_complex(t); };
 
+// A local class template stands in for std::complex wherever a value has to
+// be constructed. The MSVC STL deprecates std::complex's constructor for any
+// element type other than float, double or long double (STL4037), and these
+// tests build with warnings as errors; box keeps the round-trip check free of
+// that entanglement, and free of any element type's own semantics. Merely
+// naming std::complex<int> stays fine, which is all the trait-level checks
+// below do.
+template<class T>
+struct box
+{
+        T value;
+        auto operator==(box const&) const -> bool = default;
+};
+
+template<specialization_of<box> T>
+constexpr auto unwrap(T b) noexcept
+{
+        return b.value;
+}
+
+template<class T>
+concept has_unwrap = requires (T t) { unwrap(t); };
+
 BOOST_AUTO_TEST_CASE(SpecializationOf)
 {
         XSTD_CONSTEXPR_CHECK((specialization_of<std::complex<int>, std::complex>));
@@ -56,9 +79,14 @@ BOOST_AUTO_TEST_CASE(SpecializationOf)
         XSTD_CONSTEXPR_CHECK((specialization_of<int, std::complex> == is_specialization_of_v<int, std::complex>));
 
         // used as a type-constraint, it constrains rather than hard-errors
-        XSTD_CONSTEXPR_CHECK(has_as_complex<std::complex<int>>);
+        XSTD_CONSTEXPR_CHECK(has_as_complex<std::complex<double>>);
         XSTD_CONSTEXPR_CHECK(!has_as_complex<int>);
-        XSTD_CONSTEXPR_CHECK(as_complex(std::complex<int>(1, 2)) == std::complex<int>(1, 2));
+
+        // and the constrained template actually runs for a matching argument
+        XSTD_CONSTEXPR_CHECK((specialization_of<box<int>, box>));
+        XSTD_CONSTEXPR_CHECK(has_unwrap<box<int>>);
+        XSTD_CONSTEXPR_CHECK(!has_unwrap<int>);
+        XSTD_CONSTEXPR_CHECK_EQUAL(unwrap(box<int>{42}), 42);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -15,7 +15,8 @@ BOOST_AUTO_TEST_SUITE(Concepts)
 
 enum unscoped { u0 };
 enum class scoped : unsigned { s0 };
-struct not_an_enum {};
+struct not_an_enum
+{};
 
 BOOST_AUTO_TEST_CASE(Enumeration)
 {

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -28,6 +28,11 @@ BOOST_AUTO_TEST_CASE(IsSpecializationOf)
 template<int N>
 using int_ = std::integral_constant<int, N>;
 
+enum class color : unsigned { red = 1 };
+
+template<color N>
+using color_ = std::integral_constant<color, N>;
+
 BOOST_AUTO_TEST_CASE(IsIntegralConstant)
 {
         XSTD_CONSTEXPR_CHECK((is_integral_constant_v<std::true_type, bool>));
@@ -36,6 +41,19 @@ BOOST_AUTO_TEST_CASE(IsIntegralConstant)
 
         XSTD_CONSTEXPR_CHECK((is_integral_constant_v<int_<0>, int>));
         XSTD_CONSTEXPR_CHECK((!is_integral_constant_v<int, int>));
+
+        // std::integral_constant's first parameter is any type usable as a
+        // non-type template parameter, not just an integral one, and the
+        // enum case is what xstd::to_underlying is built on. Pinned here
+        // because narrowing this trait to std::integral would silently
+        // break that without failing any of the checks above.
+        XSTD_CONSTEXPR_CHECK((is_integral_constant_v<color_<color::red>, color>));
+        XSTD_CONSTEXPR_CHECK((!is_integral_constant_v<color, color>));
+
+        // the wrapped type has to match: an integral_constant over one type
+        // is not one over another
+        XSTD_CONSTEXPR_CHECK((!is_integral_constant_v<int_<0>, unsigned>));
+        XSTD_CONSTEXPR_CHECK((!is_integral_constant_v<color_<color::red>, unsigned>));
 }
 
 struct tag1;

--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -42,6 +42,20 @@ BOOST_AUTO_TEST_CASE(ToUnderlyingType)
         XSTD_CONSTEXPR_CHECK_EQUAL(to_underlying(e5_<e5{}>()), static_cast<unsigned>(0));
 }
 
+template<class T>
+concept has_to_underlying = requires (T t) { xstd::to_underlying(t); };
+
+BOOST_AUTO_TEST_CASE(ToUnderlyingTypeIsConstrained)
+{
+        XSTD_CONSTEXPR_CHECK(has_to_underlying<e1_<e1{}>>);
+
+        // the enumeration constraint is checked before the return type is
+        // formed, so a non-enum argument is a substitution failure rather
+        // than an ill-formed underlying_type_t (CWG2369, see design.md)
+        XSTD_CONSTEXPR_CHECK((!has_to_underlying<std::integral_constant<int, 0>>));
+        XSTD_CONSTEXPR_CHECK(!has_to_underlying<double>);
+}
+
 BOOST_AUTO_TEST_CASE(AlignedSize)
 {
         // clang-format off


### PR DESCRIPTION
Adds a new public header, `<xstd/concepts.hpp>`, holding two concepts, and switches `xstd::to_underlying` over to the first of them.

## `xstd::enumeration`

`<concepts>` names the built-in numeric categories — `integral`, `signed_integral`, `unsigned_integral`, `floating_point` — but has nothing for enums. `include/xstd/utility.hpp` said so directly:

> `is_enum_v` is a variable template rather than a concept, so it cannot become a type-constraint on `Enum`.

`to_underlying` now reads:

```cpp
template<enumeration Enum, Enum N>
[[nodiscard]] constexpr auto to_underlying(std::integral_constant<Enum, N>) noexcept
```

This does not disturb the CWG2369 ordering that the deduced return type works around (`doc/design.md`, "Why some return types are deduced and the rest are spelled out"). A type-constraint and a requires-clause in the template head are both associated constraints, checked at the same point, so the two forms are interchangeable for ordering purposes. Verified against Clang 18 — well before the Clang 21 fix — with both a deduced and a spelled-out return type: `to_underlying(non_enum)` inside a requires-expression stays `false` rather than becoming a hard error. A test in `test/src/utility.cpp` now pins that.

## `xstd::specialization_of`

The constraint form of the existing trait. It earns a place next to `is_specialization_of` rather than duplicating it, because only a concept can be partially applied in a type-constraint:

```cpp
template<xstd::specialization_of<std::complex> T>
constexpr auto real_part(T z) { return z.real(); }
```

`is_specialization_of_v<T, std::complex>` has no way to produce that form. It inherits the trait's `template<class...> class` restriction on `Primary`, and the same hard error for a template with a non-type parameter.

## Naming

Both are named as the noun the type satisfies rather than `is_enum` / `is_specialization_of`, following how every concept in `<concepts>` reads (`integral`, `destructible`, `regular`). A concept sharing an unqualified name with the trait it wraps is also ambiguous under using-directives for both namespaces, which for `enumeration` would have meant colliding with `std::is_enum`.

## `is_integral_constant` and `std::integral`

A `std::integral` constraint on the wrapped type was considered and rejected. `std::integral_constant<T, v>` puts no constraint on `T` — anything usable as a non-type template parameter works — and the enum instantiation is exactly what `xstd::to_underlying` is built on, so constraining `U` would leave the trait blind to it. Every existing check in `IsIntegralConstant` used `bool` or `int`, so the change would have passed the suite silently; the enum and mismatched-type cases are now pinned by tests, and `doc/design.md` records why the constraint is not wanted.

## Also

- `CMakeLists.txt` lists the new header in the `HEADERS` file set. The test CMakeLists globs both headers and sources, so the self-sufficiency target and the unit-test target appear automatically.
- README gains a table row and a "Concepts" section; both new examples compile as written.
- `doc/design.md` gains two sections: the header's rationale (including the rule this sets — a trait gets a concept spelling when the concept enables a *use* the trait cannot, not merely so both exist), and why `is_integral_constant` stays unconstrained.

## Testing

`ctest` passes on GCC 13 for every target touched (`concepts`, `type_traits`, `utility`, `array`, plus all four header self-sufficiency targets). All three modified/added test sources also compile clean under Clang 18 with the project's `-Weverything` set and `-Werror`.

`cstdlib` is not covered here: GCC 13's libstdc++ has no `formatter` for tuple-like types (P2286R8), so `xstd::div_t` formatting does not build on this toolchain. That failure is pre-existing and untouched by this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_012oyCJ3C8KonVyb2ZXS82rR)_