### PR TITLE
Add conditional_data_member_t, tagged per member

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ xstd is a header-only C++23 library for small standard-library extensions that c
 | :-----                   | :--------          | :---------- | :-------- |
 | `<xstd/concepts.hpp>`    | `enumeration` <br> `specialization_of` | Is a type an enumeration type? <br> Constraint form of `is_specialization_of` | none <br> [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) |
 | `<xstd/cstdlib.hpp>`     | `sign` <br> `abs` <br> `uabs` <br> `div_t` <br> `div` <br> `euclidean_div` <br> `floored_div` | `constexpr`, any signed integral type <br> `constexpr`, any signed integral type <br> Total `\|x\|`, returning the unsigned type <br> `std::format` support, defaulted equality comparison <br> `constexpr`, any signed integral type <br> Euclidean division <br> Floored division | [Boost.Math](https://www.boost.org/doc/libs/1_80_0/libs/math/doc/html/math_toolkit/sign_functions.html) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Rust `unsigned_abs`](https://doc.rust-lang.org/std/primitive.i32.html#method.unsigned_abs) (no C++ equivalent) <br> [p2286r8](https://wg21.link/p2286r8) <br> [p0533r9](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p0533r9.pdf) (C++23, not yet implemented) <br> [Euclidean division](https://en.wikipedia.org/wiki/Euclidean_division) <br> [Floored division](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf) |
-| `<xstd/type_traits.hpp>` | `is_specialization_of` <br> `is_integral_constant` <br> `tagged_empty` <br> `optional_type` | Is a type a class template specialization? <br> Is a type an `integral_constant`? <br> A tagged empty type <br> An optional type | [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) <br> none <br> none <br> none |
+| `<xstd/type_traits.hpp>` | `is_specialization_of` <br> `is_integral_constant` <br> `empty_type` <br> `conditional_data_member_t` | Is a type a class template specialization? <br> Is a type an `integral_constant`? <br> A tagged empty type <br> A conditionally present member | [p2098r1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2098r1.pdf) (not adopted) <br> none <br> none <br> none |
 | `<xstd/utility.hpp>`     | `to_underlying` <br> `aligned_size` | `std::integral_constant` overload <br> Round a size up to a multiple of an alignment | none <br> none |
 
 ## Using xstd
@@ -154,6 +154,27 @@ static_assert(!xstd::is_specialization_of_v<int, std::complex>);
 ```
 
 `xstd::is_specialization_of` isn't fully general: its `Primary` parameter is constrained to `template<class...> class`, so it only accepts class templates whose parameters are all types. A template with a non-type parameter, like `std::array` (`template<class, size_t>`), doesn't just evaluate to `false` here - passing it as the second argument is a hard compile error, since its template template parameter kind doesn't match `template<class...> class`. See [doc/design.md](doc/design.md) for why.
+
+`xstd::conditional_data_member_t` carries a data member only when a compile-time condition holds. C++ has no way to leave a member out, so the member always exists and its *type* is conditional: `Type` when the condition holds, `xstd::empty_type<Tag>` when it doesn't. Paired with `[[no_unique_address]]`, the absent case costs no storage:
+
+```cpp
+#include <xstd/type_traits.hpp>
+
+template<bool HasBounds>
+struct sprite
+{
+        [[no_unique_address]] xstd::conditional_data_member_t<HasBounds, unsigned, struct width_tag>  width;
+        [[no_unique_address]] xstd::conditional_data_member_t<HasBounds, unsigned, struct height_tag> height;
+        char frame;
+};
+
+static_assert(sizeof(sprite<false>) == sizeof(char));
+static_assert(sizeof(sprite<true>) > sizeof(sprite<false>));
+```
+
+`Tag` names the member, not `Type`, and is required rather than deduced from it. Two `[[no_unique_address]]` subobjects of the same type must have distinct addresses, so absent members sharing one empty type stop overlapping: `sprite<false>` would be 2 bytes instead of 1. An elaborated-type-specifier declares each tag in place, so no separate declarations are needed.
+
+`[[no_unique_address]]` is a no-op on MSVC's ABI, which spells it `[[msvc::no_unique_address]]`. The type-level behavior is the same everywhere; the layout saving is not.
 
 ### Concepts
 

--- a/include/xstd/type_traits.hpp
+++ b/include/xstd/type_traits.hpp
@@ -6,7 +6,7 @@
 #ifndef XSTD_TYPE_TRAITS_HPP
 #define XSTD_TYPE_TRAITS_HPP
 
-#include <compare>     // strong_ordering (tagged_empty's defaulted <=>)
+#include <compare>     // strong_ordering (empty_type's defaulted <=>)
 #include <type_traits> // bool_constant, conditional_t, integral_constant, is_same_v, remove_cvref_t
 
 namespace xstd {
@@ -30,23 +30,33 @@ template<class T, template<class...> class Primary>
 using is_specialization_of = std::bool_constant<is_specialization_of_v<T, Primary>>;
 
 template<class Tag>
-struct tagged_empty
+struct empty_type
 {
-        tagged_empty() = default;
+        empty_type() = default;
 
         // constrained so that this catch-all never hijacks copy or move
         // construction from the (trivial) special member functions
         // clang-format off
         template<class... Args>
-                requires (!(std::is_same_v<std::remove_cvref_t<Args>, tagged_empty> || ...))
-        constexpr explicit tagged_empty(Args&&...) noexcept {}
+                requires (!(std::is_same_v<std::remove_cvref_t<Args>, empty_type> || ...))
+        constexpr explicit empty_type(Args&&...) noexcept {}
         // clang-format on
 
-        auto operator<=>(tagged_empty const&) const = default;
+        auto operator<=>(empty_type const&) const = default;
 };
 
-template<bool Condition, class Base>
-using optional_type = std::conditional_t<Condition, Base, tagged_empty<Base>>;
+// Tag names the member, not the type it stands in for: two
+// [[no_unique_address]] subobjects of the same empty type must have
+// distinct addresses, so two absent members sharing a tag stop overlapping
+// and grow the class. Tagging by Type instead would make that collision a
+// silent function of the member types, so Tag is required rather than
+// defaulted. An elaborated-type-specifier declares one in place, without a
+// separate declaration per member:
+//
+//      conditional_data_member_t<Condition, set_type, struct piece_order_tag> m_piece_order [[no_unique_address]];
+//
+template<bool Condition, class Type, class Tag>
+using conditional_data_member_t = std::conditional_t<Condition, Type, empty_type<Tag>>;
 
 } // namespace xstd
 

--- a/include/xstd/type_traits.hpp
+++ b/include/xstd/type_traits.hpp
@@ -32,17 +32,20 @@ using is_specialization_of = std::bool_constant<is_specialization_of_v<T, Primar
 template<class Tag>
 struct empty_type
 {
-        empty_type() = default;
+        [[nodiscard]] constexpr empty_type() noexcept = default;
 
         // constrained so that this catch-all never hijacks copy or move
         // construction from the (trivial) special member functions
         // clang-format off
         template<class... Args>
                 requires (!(std::is_same_v<std::remove_cvref_t<Args>, empty_type> || ...))
-        constexpr explicit empty_type(Args&&...) noexcept {}
+        [[nodiscard]] constexpr explicit empty_type(Args&&...) noexcept {}
         // clang-format on
 
-        auto operator<=>(empty_type const&) const = default;
+        // a hidden friend, so it is found by argument-dependent lookup only;
+        // still implicitly declares the defaulted operator== that lets an
+        // enclosing class default its own comparisons over this member
+        [[nodiscard]] friend constexpr auto operator<=>(empty_type const&, empty_type const&) noexcept = default;
 };
 
 // Tag names the member, not the type it stands in for: two

--- a/include/xstd/type_traits.hpp
+++ b/include/xstd/type_traits.hpp
@@ -45,7 +45,8 @@ struct empty_type
         // a hidden friend, so it is found by argument-dependent lookup only;
         // still implicitly declares the defaulted operator== that lets an
         // enclosing class default its own comparisons over this member
-        [[nodiscard]] friend constexpr auto operator<=>(empty_type const&, empty_type const&) noexcept = default;
+        [[nodiscard]] friend constexpr auto operator<=>(empty_type const&, empty_type const&) noexcept
+                -> std::strong_ordering = default;
 };
 
 // Tag names the member, not the type it stands in for: two

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -6,8 +6,9 @@
 #include <xstd/type_traits.hpp>     // is_specialization_of, is_integral_constant, empty_type, conditional_data_member_t
 #include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
+#include <compare>                  // strong_ordering
 #include <complex>                  // complex
-#include <type_traits>              // integral_constant, is_constructible_v, is_convertible_v, is_empty_v, is_same_v, is_trivially_constructible_v, is_trivially_copyable_v
+#include <type_traits>              // integral_constant, is_constructible_v, is_convertible_v, is_empty_v, is_nothrow_constructible_v, is_nothrow_default_constructible_v, is_same_v, is_trivially_constructible_v, is_trivially_copyable_v
 
 using namespace xstd;
 
@@ -78,9 +79,18 @@ BOOST_AUTO_TEST_CASE(EmptyType)
         XSTD_CONSTEXPR_CHECK((std::is_trivially_constructible_v<empty1, empty1 const&>));
         XSTD_CONSTEXPR_CHECK((std::is_trivially_constructible_v<empty1, empty1&&>));
 
-        // stateless: all instances compare equal, regardless of construction
+        // neither constructor can throw
+        XSTD_CONSTEXPR_CHECK(std::is_nothrow_default_constructible_v<empty1>);
+        XSTD_CONSTEXPR_CHECK((std::is_nothrow_constructible_v<empty1, int, double>));
+
+        // stateless: all instances compare equal, regardless of construction.
+        // operator<=> is a hidden friend, so these also pin that ADL finds it
+        // and that it still implies a defaulted operator==
         XSTD_CONSTEXPR_CHECK(empty1(1, 2.0) == empty1());
         XSTD_CONSTEXPR_CHECK(empty1() == empty1(42));
+        XSTD_CONSTEXPR_CHECK((empty1() <=> empty1()) == std::strong_ordering::equal);
+        XSTD_CONSTEXPR_CHECK(noexcept(empty1() == empty1()));
+        XSTD_CONSTEXPR_CHECK(noexcept(empty1() <=> empty1()));
 }
 
 // the tag can be declared in place, in the template argument list itself,

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -3,7 +3,7 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <xstd/type_traits.hpp>     // is_specialization_of, is_integral_constant, tagged_empty, optional_type
+#include <xstd/type_traits.hpp>     // is_specialization_of, is_integral_constant, empty_type, conditional_data_member_t
 #include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
 #include <complex>                  // complex
@@ -59,10 +59,10 @@ BOOST_AUTO_TEST_CASE(IsIntegralConstant)
 struct tag1;
 struct tag2;
 
-BOOST_AUTO_TEST_CASE(TaggedEmpty)
+BOOST_AUTO_TEST_CASE(EmptyType)
 {
-        using empty1 = tagged_empty<tag1>;
-        using empty2 = tagged_empty<tag2>;
+        using empty1 = empty_type<tag1>;
+        using empty2 = empty_type<tag2>;
 
         XSTD_CONSTEXPR_CHECK((std::is_empty_v<empty1>));
         XSTD_CONSTEXPR_CHECK((!std::is_same_v<empty1, empty2>));
@@ -83,11 +83,34 @@ BOOST_AUTO_TEST_CASE(TaggedEmpty)
         XSTD_CONSTEXPR_CHECK(empty1() == empty1(42));
 }
 
-BOOST_AUTO_TEST_CASE(OptionalType)
+// the tag can be declared in place, in the template argument list itself,
+// which is how a class with conditional members names each of them without
+// a separate declaration per tag. Both stand in for the same Type here:
+// that is exactly the case an unwritable tag would let collide.
+using member1 = conditional_data_member_t<false, tag1, struct member1_tag>;
+using member2 = conditional_data_member_t<false, tag1, struct member2_tag>;
+
+BOOST_AUTO_TEST_CASE(ConditionalDataMember)
 {
-        XSTD_CONSTEXPR_CHECK((std::is_same_v<optional_type<true, tag1>, tag1>));
-        XSTD_CONSTEXPR_CHECK((std::is_same_v<optional_type<false, tag1>, tagged_empty<tag1>>));
-        XSTD_CONSTEXPR_CHECK((std::is_empty_v<optional_type<false, tag1>>));
+        XSTD_CONSTEXPR_CHECK((std::is_same_v<conditional_data_member_t<true, tag1, tag2>, tag1>));
+        XSTD_CONSTEXPR_CHECK((std::is_same_v<conditional_data_member_t<false, tag1, tag2>, empty_type<tag2>>));
+        XSTD_CONSTEXPR_CHECK((std::is_empty_v<conditional_data_member_t<false, tag1, tag2>>));
+
+        // the tag names the member, not the type it stands in for, so two
+        // absent members over the same Type still get distinct empty types
+        // and can go on overlapping in the layout
+        XSTD_CONSTEXPR_CHECK((std::is_empty_v<member1>));
+        XSTD_CONSTEXPR_CHECK((std::is_empty_v<member2>));
+        XSTD_CONSTEXPR_CHECK((!std::is_same_v<member1, member2>));
+
+        // the tag is inert when the member is present: same Type, same tags
+        // as above, and the two agree once the condition holds
+        XSTD_CONSTEXPR_CHECK((std::is_same_v<
+                              conditional_data_member_t<true, tag1, struct member1_tag>,
+                              conditional_data_member_t<true, tag1, struct member2_tag>>));
+
+        // an absent member never needs its tag defined
+        XSTD_CONSTEXPR_CHECK((std::is_empty_v<conditional_data_member_t<false, tag1, struct undefined_tag>>));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

The empty stand-in for an absent conditional member was spelled `tagged_empty<Base>`, tagging by the type the member *would have had*. This adds a required `Tag` parameter that names the member, and renames both facilities:

```diff
-template<class Tag>
-struct tagged_empty { /* ... */ };
+template<class Tag>
+struct empty_type { /* ... */ };

-template<bool Condition, class Base>
-using optional_type = std::conditional_t<Condition, Base, tagged_empty<Base>>;
+template<bool Condition, class Type, class Tag>
+using conditional_data_member_t = std::conditional_t<Condition, Type, empty_type<Tag>>;
```

`optional_type` had nothing to do with `std::optional`'s runtime presence, and what it selects is the type of a data member, so `conditional_data_member_t` matches [class.mem]'s term and mirrors `std::conditional_t`, which it is a specialization of. `tagged_empty` becomes `empty_type`, the tagging being evident from its parameter.

## Why the tag changed

Two `[[no_unique_address]]` subobjects of the same type must have distinct addresses. Tagging by the payload type meant two absent members over the same type collapsed onto one empty type, stopped overlapping, and grew the class by a byte per extra member. Measured on GCC 13 and Clang 18, three empty members ahead of a `char`:

```
shared empty type : size=3  offs a=0 b=1 c=2 real=0
distinct tags     : size=1  offs a=0 b=0 c=0 real=0
```

`Tag` is required rather than defaulted to `Type` because a default would leave whether two conditional members overlap as a silent function of their unrelated payload types. The cost is also easy to miss in a one-off measurement: with an `int`-aligned payload the stray bytes vanish into the padding and only surface later, when the payload's alignment changes — an argument for fixing it by construction rather than by inspection.

Call sites declare a tag with an elaborated-type-specifier right in the template argument list, so the tag costs one token per member and no separate declarations:

```cpp
[[no_unique_address]] xstd::conditional_data_member_t<HasBounds, unsigned, struct width_tag> width;
```

## Breaking change

`optional_type` and `tagged_empty` are gone, and every call site needs the new third argument. In-tree that is only `test/src/type_traits.cpp`. Out of tree, `rhalbersma/dctl` has three uses (`basic_action.hpp:33`, `:37`, `basic_state.hpp:41`) that will stop compiling; none of them has a live collision today, since their payload types already differ. Tracked in rhalbersma/dctl#38.

## Verification

Boost.Test isn't installed in this environment, so the suite wasn't run end to end. What was checked locally, GCC 13.3 and Clang 18.1 both:

- `test/src/type_traits.cpp` compiles clean under the flag sets `test/CMakeLists.txt` uses (`-Wall -Wextra -Wpedantic -Wconversion -Wshadow -Wsign-* -pedantic-errors -Werror`, and `-Weverything -Werror` with the project's suppressions), against a stub for the Boost.Test macros.
- `<xstd/type_traits.hpp>` still compiles as a standalone TU under the same warnings, matching the header self-sufficiency test.
- `clang-format --dry-run --Werror` clean on both changed sources.
- Every size claim in the new README section was compiled and asserted, including the "vanishes into padding" one.

New checks are `static_assert`/`XSTD_CONSTEXPR_CHECK` type-identity assertions only — no layout assertions, since `[[no_unique_address]]` is a no-op on the MSVC ABI and the MSVC and Clang-CL legs are required.

## Docs

README feature table updated, plus a short `conditional_data_member_t` example under **Type traits** covering the idiom, the tag rationale, and the MSVC caveat.