### PR TITLE
Strengthen div_t's formatter and stream inserter signatures

### DIFF
--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -96,6 +96,24 @@ struct div_t
 {
         T quot, rem;
         [[nodiscard]] friend constexpr auto operator==(div_t const&, div_t const&) noexcept -> bool = default;
+
+        // narrow std::ostream only, not the full basic_ostream<charT, traits>
+        // generality (no wide-character support): this exists solely so
+        // Boost.Test can print div_t values in test diagnostics. Application
+        // code should format these types via std::format/std::print directly
+        // rather than through operator<<.
+        //
+        // A hidden friend, matching operator== above: reachable by
+        // argument-dependent lookup on div_t and nothing else, so it never
+        // joins the candidate set of an unrelated operator<<. Deliberately
+        // not [[nodiscard]] - discarding the returned stream is what an
+        // ordinary "ostr << d;" statement does. The body names the formatter
+        // specialization declared below this class, which is fine: a friend
+        // definition is only instantiated at its point of use.
+        friend auto operator<<(std::ostream& ostr, div_t const& d) -> std::ostream&
+        {
+                return ostr << std::format("{}", d);
+        }
 };
 
 // Aggregate class template argument deduction would already deduce this, but
@@ -200,26 +218,15 @@ template<std::signed_integral T>
 template<class T>
 struct std::formatter<xstd::div_t<T>> : std::formatter<std::tuple<T const&, T const&>>
 {
-        auto format(xstd::div_t<T> const& d, auto& ctx) const
+        // not constexpr: no specialization could ever be constant-evaluated,
+        // since the tuple formatter this delegates to is not itself constexpr.
+        // That would be ill-formed no diagnostic required, so both compilers
+        // accept it in silence rather than rejecting it.
+        [[nodiscard]] auto format(xstd::div_t<T> const& d, auto& ctx) const
+                -> decltype(ctx.out())
         {
                 return std::formatter<std::tuple<T const&, T const&>>::format(std::tie(d.quot, d.rem), ctx);
         }
 };
-
-namespace xstd {
-
-// narrow std::ostream only, not the full basic_ostream<charT, traits>
-// generality (no wide-character support): this exists solely so Boost.Test
-// can print div_t values in test diagnostics. Application code should format
-// these types via std::format/std::print directly rather than through
-// operator<<.
-template<std::signed_integral T>
-auto operator<<(std::ostream& ostr, div_t<T> const& d)
-        -> std::ostream&
-{
-        return ostr << std::format("{}", d);
-}
-
-} // namespace xstd
 
 #endif // XSTD_CSTDLIB_HPP


### PR DESCRIPTION
Follow-up to #114, which is merged; this branch restarts from `main`.

## `formatter<div_t<T>>::format`

```diff
-        auto format(xstd::div_t<T> const& d, auto& ctx) const
+        [[nodiscard]] auto format(xstd::div_t<T> const& d, auto& ctx) const
+                -> decltype(ctx.out())
```

It returns the output iterator, and dropping it silently loses the write position, so `[[nodiscard]]` is warranted — verified it fires on a discarded call. The return type instantiates no trait, so #110's rule is to spell it rather than deduce it.

**Not `constexpr`.** Both GCC and Clang accept `constexpr` here without a word, but the tuple formatter it delegates to is not `constexpr` in any implementation, so no specialization could ever be constant-evaluated — [dcl.constexpr]/6 makes that ill-formed, no diagnostic required. The silence is the hazard, not evidence it's fine. Recorded in a comment so it doesn't get "fixed" later.

**Not `noexcept`** — formatting can throw `std::format_error`, and the output iterator can allocate.

## `operator<<`

Becomes a hidden friend of `div_t`, matching the `operator==` beside it:

```diff
-template<std::signed_integral T>
-auto operator<<(std::ostream& ostr, div_t<T> const& d)
-        -> std::ostream&
+        friend auto operator<<(std::ostream& ostr, div_t const& d) -> std::ostream&
```

Reachable by ADL on `div_t` and nothing else, so it never joins the candidate set of an unrelated `operator<<`, and it stops being a template, so there's no deduction to fail. Naming the formatter specialization declared further down the header is fine: a friend definition is only instantiated at its point of use.

**Deliberately not `[[nodiscard]]`, `noexcept`, or `constexpr`.** Discarding the returned stream is exactly what an ordinary `ostr << d;` statement does — `[[nodiscard]]` would fire on every correct use. Stream insertion and `std::format` can both throw, and `std::ostream` isn't usable in constant evaluation.

## Verification, and its limits

**This toolchain cannot exercise the formatting path.** libstdc++ 13 has no tuple formatter, and the repo requires GCC 15+; `std::format("{}", div_t<int>{1,-2})` fails identically on unmodified `main`, so that gap is pre-existing and environmental. CI is the first place the real path runs.

What was verified locally, GCC 13.3 and Clang 18.1 both:

- `<xstd/cstdlib.hpp>` still compiles standalone under the repo's warning flags (`-Weverything -Werror` modulo one pre-existing `-Wpre-c++20-compat-pedantic` that fires identically on unmodified `main`).
- ADL reaches the hidden friend and it yields `std::ostream&`, checked via a `requires`-expression for several `T` — this needs only the declaration, so it works despite the missing tuple formatter.
- `&xstd::operator<<` is now a hard error, confirming the name really left namespace scope.
- The `[[nodiscard]]` and `-> decltype(ctx.out())` combination, and the ordering question of a hidden friend naming a formatter declared later, were both verified on structurally identical stand-ins built from `std::formatter<int>`, which this libstdc++ does have.
- `clang-format --dry-run --Werror` clean.

No test changes: `test/src/cstdlib.cpp` already covers both paths (`std::format` at :239/:294, `oss <<` at :245/:297) and needs no edit, since ADL finds the hidden friend exactly where the old namespace-scope template was found.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoDYmSTvTsue9MbmiYegEK)_