### PR TITLE
Spell logical operators as alternative tokens, and analyze the tests with clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,3 +24,12 @@ Checks: >
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'include/xstd/.*'
 FormatStyle: none
+CheckOptions:
+  # The logical operators are spelled as the alternative tokens throughout,
+  # which reads with the declarative style of the constraints and assertions
+  # they appear in - and a "not" cannot be skimmed past the way a lone "!"
+  # can. Only the three logical ones: "!=" stays "!=", since "not_eq" and the
+  # bitwise spellings (bitand, compl, ...) are harder to read than what they
+  # replace, not easier. The check is inert until its operator list is set,
+  # so naming them here is what turns it on.
+  readability-operators-representation.BinaryOperators: 'not;and;or'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,8 +5,10 @@
 
 ---
 # Static analysis for the public headers, run by the Clang-Tidy workflow
-# over the generated header self-sufficiency translation units (the
-# Boost.Test sources are excluded: test macros drown the signal in noise).
+# over the generated header self-sufficiency translation units. The
+# Boost.Test sources are analyzed by the same workflow under test/.clang-tidy,
+# which inherits everything here and drops the two checks that only misfire
+# on fixtures.
 Checks: >
   bugprone-*,
   clang-analyzer-*,

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -112,10 +112,11 @@ jobs:
             "$GITHUB_WORKSPACE/build/test/header_self_sufficiency/.*" \
             2>&1 | tee clang-tidy-report.txt
 
-      # The Boost.Test sources, under test/.clang-tidy. Analyzed second
-      # rather than in the same pass, so that a finding names the tree whose
-      # rulebook it came from; a red headers step stops this one, which is
-      # the right order to fix them in anyway.
+      # The Boost.Test sources, under test/.clang-tidy, which inherits the
+      # root configuration and drops the three checks that only misfire on
+      # fixtures. Analyzed second rather than in the same pass, so that a
+      # finding names the tree whose rulebook it came from; a red headers
+      # step stops this one, which is the right order to fix them in anyway.
       - name: Run clang-tidy over the test sources
         shell: bash
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -96,15 +96,32 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
 
       # Analyze the public headers through the generated header
-      # self-sufficiency translation units. The Boost.Test sources are left
-      # out on purpose: the test macros drown the signal in noise. The
-      # check selection and per-check suppressions live in .clang-tidy;
-      # WarningsAsErrors there makes any finding fail this job.
+      # self-sufficiency translation units. The check selection and
+      # per-check suppressions live in .clang-tidy; WarningsAsErrors there
+      # makes any finding fail this job.
+      #
+      # "shell: bash" rather than the default shell, in both this step and
+      # the next: the default is "bash -e {0}", with no -o pipefail, so the
+      # exit status of these pipelines would be tee's rather than
+      # clang-tidy's and no finding could ever redden the job. Naming the
+      # shell explicitly gets "bash --noprofile --norc -eo pipefail {0}".
       - name: Run clang-tidy over the public headers
+        shell: bash
         run: |
           run-clang-tidy-22 -quiet -p build \
             "$GITHUB_WORKSPACE/build/test/header_self_sufficiency/.*" \
             2>&1 | tee clang-tidy-report.txt
+
+      # The Boost.Test sources, under test/.clang-tidy. Analyzed second
+      # rather than in the same pass, so that a finding names the tree whose
+      # rulebook it came from; a red headers step stops this one, which is
+      # the right order to fix them in anyway.
+      - name: Run clang-tidy over the test sources
+        shell: bash
+        run: |
+          run-clang-tidy-22 -quiet -p build \
+            "$GITHUB_WORKSPACE/test/src/.*" \
+            2>&1 | tee -a clang-tidy-report.txt
 
       - name: Publish clang-tidy summary
         if: always()

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ See [doc/design.md](doc/design.md) for the rationale behind these APIs' shapes (
 #include <xstd/type_traits.hpp>
 
 static_assert(xstd::is_specialization_of_v<std::complex<double>, std::complex>);
-static_assert(!xstd::is_specialization_of_v<int, std::complex>);
+static_assert(not xstd::is_specialization_of_v<int, std::complex>);
 ```
 
 `xstd::is_specialization_of` isn't fully general: its `Primary` parameter is constrained to `template<class...> class`, so it only accepts class templates whose parameters are all types. A template with a non-type parameter, like `std::array` (`template<class, size_t>`), doesn't just evaluate to `false` here - passing it as the second argument is a hard compile error, since its template template parameter kind doesn't match `template<class...> class`. See [doc/design.md](doc/design.md) for why.

--- a/doc/design.md
+++ b/doc/design.md
@@ -156,7 +156,7 @@ arguments the constraint would have rejected:
     template<std::signed_integral T>
     constexpr auto uabs(T x) noexcept -> std::make_unsigned_t<T>;
 
-    static_assert(!has_uabs<double>);   // hard error on Clang < 21
+    static_assert(not has_uabs<double>);   // hard error on Clang < 21
 
 `std::make_unsigned_t<double>` is ill-formed, not a substitution failure, so
 `uabs(1.0)` inside a requires-expression stops the compile instead of

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -110,7 +110,8 @@ struct div_t
         // ordinary "ostr << d;" statement does. The body names the formatter
         // specialization declared below this class, which is fine: a friend
         // definition is only instantiated at its point of use.
-        friend auto operator<<(std::ostream& ostr, div_t const& d) -> std::ostream&
+        friend auto operator<<(std::ostream& ostr, div_t const& d)
+                -> std::ostream&
         {
                 return ostr << std::format("{}", d);
         }

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -138,7 +138,7 @@ template<std::signed_integral T>
         -> div_t<T>
 {
         assert(denom != 0);
-        assert(not (numer == std::numeric_limits<T>::min() and denom == -1));
+        assert(numer != std::numeric_limits<T>::min() or denom != -1);
         auto const qT = static_cast<T>(numer / denom);
         auto const rT = static_cast<T>(numer % denom);
         // Safe in T at every width, with no widening: denom * qT is exactly

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -138,7 +138,7 @@ template<std::signed_integral T>
         -> div_t<T>
 {
         assert(denom != 0);
-        assert(!(numer == std::numeric_limits<T>::min() && denom == -1));
+        assert(not (numer == std::numeric_limits<T>::min() and denom == -1));
         auto const qT = static_cast<T>(numer / denom);
         auto const rT = static_cast<T>(numer % denom);
         // Safe in T at every width, with no widening: denom * qT is exactly
@@ -150,7 +150,7 @@ template<std::signed_integral T>
         // and rT, so it could only fail if this one had already failed.
         assert(numer == (denom * qT) + rT);
         assert(uabs(rT) < uabs(denom));
-        assert(sign(rT) == sign(numer) || rT == 0);
+        assert(sign(rT) == sign(numer) or rT == 0);
         return {.quot = qT, .rem = rT};
 }
 
@@ -199,7 +199,7 @@ template<std::signed_integral T>
         auto const qF = static_cast<T>(qT - (adjust ? 1 : 0));
         auto const rF = static_cast<T>(rT + (adjust ? denom : 0));
         assert(uabs(rF) < uabs(denom));
-        assert(rF == 0 || sign(rF) == sign(denom));
+        assert(rF == 0 or sign(rF) == sign(denom));
         return {.quot = qF, .rem = rF};
 }
 

--- a/include/xstd/cstdlib.hpp
+++ b/include/xstd/cstdlib.hpp
@@ -206,17 +206,25 @@ template<std::signed_integral T>
 } // namespace xstd
 
 // Specialized via qualified-id (template<class T> struct std::formatter<...>)
-// rather than inside a reopened "namespace std { ... }" block: both forms
-// are equally legal here (the standard explicitly permits specializing
-// std::formatter for program-defined types), but the qualified form avoids
-// clang-tidy's bugprone-std-namespace-modification finding, which otherwise
-// flags any reopening of namespace std regardless of what's inside it.
+// rather than inside a reopened "namespace std { ... }" block. Both forms are
+// equally legal here - [namespace.std]/2 explicitly permits adding a template
+// specialization to namespace std when it depends on a program-defined type
+// and meets the original template's requirements - and the qualified form is
+// the narrower of the two, since it can only ever declare the one
+// specialization it names.
+//
+// clang-tidy's bugprone-std-namespace-modification used to flag only the
+// reopened form, which is what this spelling was chosen for; as of clang-tidy
+// 22 it flags both, without exempting the specializations the standard allows.
+// Silenced on the declaration rather than repo-wide: the check still has a
+// real job to do on any other addition to namespace std.
 //
 // A partial specialization over div_t's element type also defers the body's
 // instantiation to the point of use, so merely including this header no
 // longer requires a standard library that implements tuple formatting; only
 // actually formatting an xstd::div_t does.
 template<class T>
+// NOLINTNEXTLINE(bugprone-std-namespace-modification): permitted by [namespace.std]/2, see above
 struct std::formatter<xstd::div_t<T>> : std::formatter<std::tuple<T const&, T const&>>
 {
         // not constexpr: no specialization could ever be constant-evaluated,

--- a/include/xstd/type_traits.hpp
+++ b/include/xstd/type_traits.hpp
@@ -38,7 +38,7 @@ struct empty_type
         // construction from the (trivial) special member functions
         // clang-format off
         template<class... Args>
-                requires (!(std::is_same_v<std::remove_cvref_t<Args>, empty_type> || ...))
+                requires (not (std::is_same_v<std::remove_cvref_t<Args>, empty_type> or ...))
         [[nodiscard]] constexpr explicit empty_type(Args&&...) noexcept {}
         // clang-format on
 

--- a/include/xstd/type_traits.hpp
+++ b/include/xstd/type_traits.hpp
@@ -57,7 +57,7 @@ struct empty_type
 // defaulted. An elaborated-type-specifier declares one in place, without a
 // separate declaration per member:
 //
-//      conditional_data_member_t<Condition, set_type, struct piece_order_tag> m_piece_order [[no_unique_address]];
+//      conditional_data_member_t<Condition, Type, struct variable_tag> m_variable [[no_unique_address]];
 //
 template<bool Condition, class Type, class Tag>
 using conditional_data_member_t = std::conditional_t<Condition, Type, empty_type<Tag>>;

--- a/include/xstd/type_traits.hpp
+++ b/include/xstd/type_traits.hpp
@@ -38,7 +38,7 @@ struct empty_type
         // construction from the (trivial) special member functions
         // clang-format off
         template<class... Args>
-                requires (not (std::is_same_v<std::remove_cvref_t<Args>, empty_type> or ...))
+                requires ((not std::is_same_v<std::remove_cvref_t<Args>, empty_type>) and ...)
         [[nodiscard]] constexpr explicit empty_type(Args&&...) noexcept {}
         // clang-format on
 

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -1,0 +1,31 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+---
+# Static analysis for the Boost.Test sources. InheritParentConfig keeps the
+# root .clang-tidy's check selection, CheckOptions and WarningsAsErrors -
+# without it this file would replace that configuration rather than extend
+# it, and the tests would be analyzed by a different rulebook than the
+# headers they exercise.
+#
+# Note that this file does not reach the generated header self-sufficiency
+# translation units: those live under the build directory, so they resolve
+# to the root .clang-tidy and keep the stricter production rules.
+#
+# Only two checks are dropped, both aimed at production code and neither
+# saying anything true about a fixture:
+#
+# - performance-enum-size wants the smallest underlying type. The enums here
+#   exist to be handed to the enumeration concept and to xstd::to_underlying;
+#   the underlying type is the thing under test, not a size to minimize, and
+#   narrowing it to std::uint8_t would weaken what the checks pin.
+# - readability-magic-numbers wants every literal named. A table of inputs
+#   and expected results is nothing but literals, and naming them would move
+#   the test data away from the assertion that reads it - the value of a
+#   check like abs(T{-2}) == T{2} is that both numbers are visible at once.
+InheritParentConfig: true
+Checks: >
+  -performance-enum-size,
+  -readability-magic-numbers

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -14,9 +14,19 @@
 # translation units: those live under the build directory, so they resolve
 # to the root .clang-tidy and keep the stricter production rules.
 #
-# Only two checks are dropped, both aimed at production code and neither
-# saying anything true about a fixture:
+# Four checks are dropped, none of them saying anything true about a fixture:
 #
+# - misc-use-internal-linkage wants every non-exported entity given internal
+#   linkage. Most of what it flags here is not ours to move: BOOST_AUTO_TEST_CASE
+#   expands to a struct at namespace scope, so every test case in the suite
+#   draws a finding that could only be silenced one NOLINT at a time. This is
+#   the check the workflow's old "test macros drown the signal in noise"
+#   comment was describing - it is a real effect, just a one-check one.
+# - modernize-use-designated-initializers wants div_t{.quot = q, .rem = r}.
+#   The positional spelling is the thing under test in DeducedDivT, which
+#   pins that div_t{q, r} still deduces the way the four <cstdlib> names used
+#   to; and the expected-result tables are laid out four to a line so they
+#   can be read against the inputs above them, which designators would end.
 # - performance-enum-size wants the smallest underlying type. The enums here
 #   exist to be handed to the enumeration concept and to xstd::to_underlying;
 #   the underlying type is the thing under test, not a size to minimize, and
@@ -27,5 +37,7 @@
 #   check like abs(T{-2}) == T{2} is that both numbers are visible at once.
 InheritParentConfig: true
 Checks: >
+  -misc-use-internal-linkage,
+  -modernize-use-designated-initializers,
   -performance-enum-size,
   -readability-magic-numbers

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -4,6 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <xstd/concepts.hpp>        // enumeration, specialization_of
+#include <xstd/type_traits.hpp>     // empty_type, is_specialization_of_v
 #include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK, XSTD_CONSTEXPR_CHECK_EQUAL
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
 #include <complex>                  // complex
@@ -51,6 +52,12 @@ BOOST_AUTO_TEST_CASE(SpecializationOf)
         XSTD_CONSTEXPR_CHECK((!specialization_of<int, std::complex>));
         XSTD_CONSTEXPR_CHECK((!specialization_of<std::tuple<int>, std::complex>));
         XSTD_CONSTEXPR_CHECK((!specialization_of<std::complex<int>&, std::complex>));
+
+        // nothing in the concept is specific to the standard library. The
+        // library's own class template is a program-defined primary like any
+        // other, with its tag declared in place
+        XSTD_CONSTEXPR_CHECK((specialization_of<empty_type<struct user_tag>, empty_type>));
+        XSTD_CONSTEXPR_CHECK((!specialization_of<int, empty_type>));
 
         // the concept agrees with the trait it is spelled over
         XSTD_CONSTEXPR_CHECK((specialization_of<std::complex<int>, std::complex> == is_specialization_of_v<std::complex<int>, std::complex>));

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -24,12 +24,12 @@ BOOST_AUTO_TEST_CASE(Enumeration)
         XSTD_CONSTEXPR_CHECK(enumeration<unscoped>);
         XSTD_CONSTEXPR_CHECK(enumeration<scoped>);
 
-        XSTD_CONSTEXPR_CHECK(!enumeration<int>);
-        XSTD_CONSTEXPR_CHECK(!enumeration<bool>);
-        XSTD_CONSTEXPR_CHECK(!enumeration<not_an_enum>);
-        XSTD_CONSTEXPR_CHECK(!enumeration<scoped&>);
-        XSTD_CONSTEXPR_CHECK(!enumeration<scoped*>);
-        XSTD_CONSTEXPR_CHECK(!enumeration<void>);
+        XSTD_CONSTEXPR_CHECK(not enumeration<int>);
+        XSTD_CONSTEXPR_CHECK(not enumeration<bool>);
+        XSTD_CONSTEXPR_CHECK(not enumeration<not_an_enum>);
+        XSTD_CONSTEXPR_CHECK(not enumeration<scoped&>);
+        XSTD_CONSTEXPR_CHECK(not enumeration<scoped*>);
+        XSTD_CONSTEXPR_CHECK(not enumeration<void>);
 }
 
 // the partial application a type-constraint needs: the primary template alone
@@ -49,15 +49,15 @@ BOOST_AUTO_TEST_CASE(SpecializationOf)
         XSTD_CONSTEXPR_CHECK((specialization_of<std::tuple<int, char>, std::tuple>));
         XSTD_CONSTEXPR_CHECK((specialization_of<std::tuple<>, std::tuple>));
 
-        XSTD_CONSTEXPR_CHECK((!specialization_of<int, std::complex>));
-        XSTD_CONSTEXPR_CHECK((!specialization_of<std::tuple<int>, std::complex>));
-        XSTD_CONSTEXPR_CHECK((!specialization_of<std::complex<int>&, std::complex>));
+        XSTD_CONSTEXPR_CHECK((not specialization_of<int, std::complex>));
+        XSTD_CONSTEXPR_CHECK((not specialization_of<std::tuple<int>, std::complex>));
+        XSTD_CONSTEXPR_CHECK((not specialization_of<std::complex<int>&, std::complex>));
 
         // nothing in the concept is specific to the standard library. The
         // library's own class template is a program-defined primary like any
         // other, with its tag declared in place
         XSTD_CONSTEXPR_CHECK((specialization_of<empty_type<struct user_tag>, empty_type>));
-        XSTD_CONSTEXPR_CHECK((!specialization_of<int, empty_type>));
+        XSTD_CONSTEXPR_CHECK((not specialization_of<int, empty_type>));
 
         // the concept agrees with the trait it is spelled over
         XSTD_CONSTEXPR_CHECK((specialization_of<std::complex<int>, std::complex> == is_specialization_of_v<std::complex<int>, std::complex>));
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(SpecializationOf)
 
         // used as a type-constraint, it constrains rather than hard-errors
         XSTD_CONSTEXPR_CHECK(has_as_complex<std::complex<double>>);
-        XSTD_CONSTEXPR_CHECK(!has_as_complex<int>);
+        XSTD_CONSTEXPR_CHECK(not has_as_complex<int>);
 
         // and the constrained template actually runs for a matching argument,
         // which the two checks above cannot show: a requires-expression's

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -53,7 +53,7 @@ template<class T>
 struct box
 {
         T value;
-        [[nodiscard]] constexpr auto operator==(box const&) const noexcept -> bool = default;
+        [[nodiscard]] friend constexpr auto operator==(box const&, box const&) noexcept -> bool = default;
 };
 
 template<specialization_of<box> T>

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -33,7 +33,8 @@ BOOST_AUTO_TEST_CASE(Enumeration)
 
 // the partial application a type-constraint needs: the primary template alone
 template<specialization_of<std::complex> T>
-constexpr auto as_complex(T z) noexcept -> T
+[[nodiscard]] constexpr auto as_complex(T z) noexcept
+        -> T
 {
         return z;
 }
@@ -52,11 +53,11 @@ template<class T>
 struct box
 {
         T value;
-        auto operator==(box const&) const -> bool = default;
+        [[nodiscard]] constexpr auto operator==(box const&) const noexcept -> bool = default;
 };
 
 template<specialization_of<box> T>
-constexpr auto unwrap(T b) noexcept
+[[nodiscard]] constexpr auto unwrap(T b) noexcept
 {
         return b.value;
 }

--- a/test/src/concepts.cpp
+++ b/test/src/concepts.cpp
@@ -42,29 +42,6 @@ template<specialization_of<std::complex> T>
 template<class T>
 concept has_as_complex = requires (T t) { as_complex(t); };
 
-// A local class template stands in for std::complex wherever a value has to
-// be constructed. The MSVC STL deprecates std::complex's constructor for any
-// element type other than float, double or long double (STL4037), and these
-// tests build with warnings as errors; box keeps the round-trip check free of
-// that entanglement, and free of any element type's own semantics. Merely
-// naming std::complex<int> stays fine, which is all the trait-level checks
-// below do.
-template<class T>
-struct box
-{
-        T value;
-        [[nodiscard]] friend constexpr auto operator==(box const&, box const&) noexcept -> bool = default;
-};
-
-template<specialization_of<box> T>
-[[nodiscard]] constexpr auto unwrap(T b) noexcept
-{
-        return b.value;
-}
-
-template<class T>
-concept has_unwrap = requires (T t) { unwrap(t); };
-
 BOOST_AUTO_TEST_CASE(SpecializationOf)
 {
         XSTD_CONSTEXPR_CHECK((specialization_of<std::complex<int>, std::complex>));
@@ -83,11 +60,16 @@ BOOST_AUTO_TEST_CASE(SpecializationOf)
         XSTD_CONSTEXPR_CHECK(has_as_complex<std::complex<double>>);
         XSTD_CONSTEXPR_CHECK(!has_as_complex<int>);
 
-        // and the constrained template actually runs for a matching argument
-        XSTD_CONSTEXPR_CHECK((specialization_of<box<int>, box>));
-        XSTD_CONSTEXPR_CHECK(has_unwrap<box<int>>);
-        XSTD_CONSTEXPR_CHECK(!has_unwrap<int>);
-        XSTD_CONSTEXPR_CHECK_EQUAL(unwrap(box<int>{42}), 42);
+        // and the constrained template actually runs for a matching argument,
+        // which the two checks above cannot show: a requires-expression's
+        // operand is unevaluated, so a body that is ill-formed on
+        // instantiation would still leave has_as_complex true. double rather
+        // than int as the element type because the MSVC STL deprecates
+        // std::complex's constructor for anything but the floating-point ones
+        // (STL4037) and these tests build with warnings as errors; merely
+        // naming std::complex<int> stays fine, which is all the checks above
+        // do.
+        XSTD_CONSTEXPR_CHECK_EQUAL((as_complex(std::complex<double>{1.0, 2.0})), (std::complex<double>{1.0, 2.0}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -6,7 +6,7 @@
 #include <xstd/cstdlib.hpp>         // abs, uabs, sign, div_t, div, euclidean_div, floored_div
 #include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK_EQUAL
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_CHECK_EQUAL, BOOST_CHECK_EQUAL_COLLECTIONS
-#include <algorithm>                // transform
+#include <algorithm>                // ranges::transform
 #include <array>                    // array
 #include <concepts>                 // same_as, signed_integral
 #include <cstdint>                  // int8_t, int16_t, int32_t, int64_t, intmax_t
@@ -338,7 +338,7 @@ BOOST_AUTO_TEST_CASE(StdDiv)
         // clang-format on
 
         std::vector<xstd::div_t<int>> std_res;
-        std::transform(input.begin(), input.end(), std::back_inserter(std_res), [](auto const& p) -> xstd::div_t<int> {
+        std::ranges::transform(input, std::back_inserter(std_res), [](auto const& p) -> xstd::div_t<int> {
                 auto const d = std::div(p.first, p.second);
                 return {d.quot, d.rem};
         });

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -62,19 +62,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Constraints, T, exact_width_types)
 
         // Unsigned arguments are outside the constraint, at every width.
         using U = std::make_unsigned_t<T>;
-        static_assert(!has_abs<U>);
-        static_assert(!has_uabs<U>);
-        static_assert(!has_sign<U>);
-        static_assert(!has_div<U, U>);
+        static_assert(not has_abs<U>);
+        static_assert(not has_uabs<U>);
+        static_assert(not has_sign<U>);
+        static_assert(not has_div<U, U>);
 
         BOOST_CHECK(true); // silence Boost.Test's "test case did not check any assertions"
 }
 
 BOOST_AUTO_TEST_CASE(NonSignedIntegralArgumentsAreRejected)
 {
-        static_assert(!has_abs<bool>);
-        static_assert(!has_abs<double>);
-        static_assert(!has_sign<char*>);
+        static_assert(not has_abs<bool>);
+        static_assert(not has_abs<double>);
+        static_assert(not has_sign<char*>);
 
         // uabs is the only one of the three whose return type is computed by a
         // trait, so it is the only one where rejecting a non-integral argument
@@ -85,13 +85,13 @@ BOOST_AUTO_TEST_CASE(NonSignedIntegralArgumentsAreRejected)
         // substitution failure - these two stop compiling instead of being
         // false. The deduced return type in the header is what keeps them
         // compiling; see doc/design.md.
-        static_assert(!has_uabs<bool>);
-        static_assert(!has_uabs<double>);
-        static_assert(!has_uabs<char*>);
+        static_assert(not has_uabs<bool>);
+        static_assert(not has_uabs<double>);
+        static_assert(not has_uabs<char*>);
 
         // Both parameters deduce the same T, so a mixed-width call is a
         // deduction failure rather than a silent conversion of one operand.
-        static_assert(!has_div<std::int32_t, std::int64_t>);
+        static_assert(not has_div<std::int32_t, std::int64_t>);
         static_assert(std::same_as<decltype(xstd::div<std::int64_t>(8, 3)), xstd::div_t<std::int64_t>>);
 
         BOOST_CHECK(true);

--- a/test/src/cstdlib.cpp
+++ b/test/src/cstdlib.cpp
@@ -8,7 +8,7 @@
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_CHECK_EQUAL, BOOST_CHECK_EQUAL_COLLECTIONS
 #include <algorithm>                // transform
 #include <array>                    // array
-#include <concepts>                 // same_as
+#include <concepts>                 // same_as, signed_integral
 #include <cstdint>                  // int8_t, int16_t, int32_t, int64_t, intmax_t
 #include <cstdlib>                  // div
 #include <format>                   // format
@@ -261,7 +261,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(StreamInsertion, T, exact_width_types)
 // instantiates them for anything it might have to report - but never
 // executed, since they only run when an assertion fails.
 template<std::signed_integral T>
-void check_built_in_width()
+auto check_built_in_width()
+        -> void
 {
         using U = std::make_unsigned_t<T>;
         using limits = std::numeric_limits<T>;

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -23,7 +23,7 @@ inline constexpr auto is_complex_v = is_complex<T>::value;
 BOOST_AUTO_TEST_CASE(IsSpecializationOf)
 {
         XSTD_CONSTEXPR_CHECK((is_complex_v<std::complex<int>>));
-        XSTD_CONSTEXPR_CHECK((!is_complex_v<int>));
+        XSTD_CONSTEXPR_CHECK((not is_complex_v<int>));
 }
 
 template<int N>
@@ -38,10 +38,10 @@ BOOST_AUTO_TEST_CASE(IsIntegralConstant)
 {
         XSTD_CONSTEXPR_CHECK((is_integral_constant_v<std::true_type, bool>));
         XSTD_CONSTEXPR_CHECK((is_integral_constant_v<std::false_type, bool>));
-        XSTD_CONSTEXPR_CHECK((!is_integral_constant_v<bool, bool>));
+        XSTD_CONSTEXPR_CHECK((not is_integral_constant_v<bool, bool>));
 
         XSTD_CONSTEXPR_CHECK((is_integral_constant_v<int_<0>, int>));
-        XSTD_CONSTEXPR_CHECK((!is_integral_constant_v<int, int>));
+        XSTD_CONSTEXPR_CHECK((not is_integral_constant_v<int, int>));
 
         // std::integral_constant's first parameter is any type usable as a
         // non-type template parameter, not just an integral one, and the
@@ -49,12 +49,12 @@ BOOST_AUTO_TEST_CASE(IsIntegralConstant)
         // because narrowing this trait to std::integral would silently
         // break that without failing any of the checks above.
         XSTD_CONSTEXPR_CHECK((is_integral_constant_v<color_<color::red>, color>));
-        XSTD_CONSTEXPR_CHECK((!is_integral_constant_v<color, color>));
+        XSTD_CONSTEXPR_CHECK((not is_integral_constant_v<color, color>));
 
         // the wrapped type has to match: an integral_constant over one type
         // is not one over another
-        XSTD_CONSTEXPR_CHECK((!is_integral_constant_v<int_<0>, unsigned>));
-        XSTD_CONSTEXPR_CHECK((!is_integral_constant_v<color_<color::red>, unsigned>));
+        XSTD_CONSTEXPR_CHECK((not is_integral_constant_v<int_<0>, unsigned>));
+        XSTD_CONSTEXPR_CHECK((not is_integral_constant_v<color_<color::red>, unsigned>));
 }
 
 struct tag1;
@@ -66,11 +66,11 @@ BOOST_AUTO_TEST_CASE(EmptyType)
         using empty2 = empty_type<tag2>;
 
         XSTD_CONSTEXPR_CHECK((std::is_empty_v<empty1>));
-        XSTD_CONSTEXPR_CHECK((!std::is_same_v<empty1, empty2>));
+        XSTD_CONSTEXPR_CHECK((not std::is_same_v<empty1, empty2>));
 
         // constructible from anything, but only explicitly
         XSTD_CONSTEXPR_CHECK((std::is_constructible_v<empty1, int, double>));
-        XSTD_CONSTEXPR_CHECK((!std::is_convertible_v<int, empty1>));
+        XSTD_CONSTEXPR_CHECK((not std::is_convertible_v<int, empty1>));
 
         // the catch-all constructor never hijacks copy/move construction,
         // not even from a non-const lvalue
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(ConditionalDataMember)
         // and can go on overlapping in the layout
         XSTD_CONSTEXPR_CHECK((std::is_empty_v<member1>));
         XSTD_CONSTEXPR_CHECK((std::is_empty_v<member2>));
-        XSTD_CONSTEXPR_CHECK((!std::is_same_v<member1, member2>));
+        XSTD_CONSTEXPR_CHECK((not std::is_same_v<member1, member2>));
 
         // the tag is inert when the member is present: same Type, same tags
         // as above, and the two agree once the condition holds

--- a/test/src/type_traits.cpp
+++ b/test/src/type_traits.cpp
@@ -8,7 +8,7 @@
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
 #include <compare>                  // strong_ordering
 #include <complex>                  // complex
-#include <type_traits>              // integral_constant, is_constructible_v, is_convertible_v, is_empty_v, is_nothrow_constructible_v, is_nothrow_default_constructible_v, is_same_v, is_trivially_constructible_v, is_trivially_copyable_v
+#include <type_traits>              // false_type, integral_constant, is_constructible_v, is_convertible_v, is_empty_v, is_nothrow_constructible_v, is_nothrow_default_constructible_v, is_same_v, is_trivially_constructible_v, is_trivially_copyable_v, true_type
 
 using namespace xstd;
 

--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -3,9 +3,10 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <xstd/utility.hpp>         // to_underlying
-#include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK_EQUAL
+#include <xstd/utility.hpp>         // to_underlying, aligned_size
+#include <xstd/test/constexpr.hpp>  // XSTD_CONSTEXPR_CHECK, XSTD_CONSTEXPR_CHECK_EQUAL
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
+#include <cstddef>                  // size_t
 #include <limits>                   // numeric_limits
 #include <type_traits>              // integral_constant
 #include <utility>                  // to_underlying

--- a/test/src/utility.cpp
+++ b/test/src/utility.cpp
@@ -53,8 +53,8 @@ BOOST_AUTO_TEST_CASE(ToUnderlyingTypeIsConstrained)
         // the enumeration constraint is checked before the return type is
         // formed, so a non-enum argument is a substitution failure rather
         // than an ill-formed underlying_type_t (CWG2369, see design.md)
-        XSTD_CONSTEXPR_CHECK((!has_to_underlying<std::integral_constant<int, 0>>));
-        XSTD_CONSTEXPR_CHECK(!has_to_underlying<double>);
+        XSTD_CONSTEXPR_CHECK((not has_to_underlying<std::integral_constant<int, 0>>));
+        XSTD_CONSTEXPR_CHECK(not has_to_underlying<double>);
 }
 
 BOOST_AUTO_TEST_CASE(AlignedSize)


### PR DESCRIPTION
Started as a one-line comment fix and grew into a style and static-analysis pass. Grouped by theme; every commit is self-contained.

## Alternative-token logical operators

`not`, `and`, `or` throughout the headers, the tests and the documentation snippets — 39 sites. `!=` is deliberately left alone: `not_eq` and the bitwise spellings are harder to read than what they replace, not easier.

`readability-operators-representation` was already enabled by the `readability-*` glob but inert, since its operator list defaults to empty. Naming the three turns it on, so the spelling cannot drift back.

Two spots needed restructuring rather than a token swap, because clang-format renders `not (expr)` as `not(expr)` — which reads like a call to a function named `not`, the exact misreading the spelling is meant to prevent. Both were resolved with De Morgan instead:

- `div`'s overflow precondition, now stated as two `!=` disjuncts, matching the shape of the `denom != 0` precondition above it.
- `empty_type`'s catch-all constructor constraint, now a fold over `and` rather than a negated fold over `or`. Verified equivalent on 15 trait probes, including the empty-pack case the two folds reach by different routes.

## clang-tidy over the test sources

Previously only the public headers were analyzed, on the grounds that test macros drown the signal in noise. That is true of exactly one check — `misc-use-internal-linkage` fires on every `BOOST_AUTO_TEST_CASE` expansion — so `test/.clang-tidy` inherits the root configuration and drops the four checks that only misfire on fixtures, rather than excluding the tree. The tests are now held to the same rulebook as the headers they exercise, including the operator spelling.

One finding was fixed rather than suppressed: `std::ranges::transform` over the input array.

The workflow steps also needed an explicit `shell: bash`. The default is `bash -e {0}`, with no `-o pipefail`, so these pipelines exited with `tee`'s status — no clang-tidy finding could ever have failed the job. Making it real immediately surfaced one: `bugprone-std-namespace-modification` now flags the qualified-id form of the `std::formatter` specialization as well as the reopened-namespace form, and the qualified spelling had been chosen for precisely that reason. Silenced on the declaration, which `[namespace.std]/2` permits, rather than repo-wide.

## Test-side signature discipline

The test helpers were written more loosely than the headers they exercise. Brought into line: trailing return types on their own indented line, `[[nodiscard]]` on the value-returning helpers, and `constexpr`/`noexcept` on the comparison operators.

The `box`/`unwrap` stand-in is gone. It existed only to supply a value for a round-trip check without constructing a `std::complex<int>`, whose constructor the MSVC STL deprecates under warnings-as-errors. A `std::complex<double>` is not deprecated and compares equal as a constant expression, so the round trip moved onto the helper the requires-expression already probes — which makes it stronger, since it now covers a body that is well-formed to call but ill-formed to instantiate. The non-std primary template case it also covered is kept, using `xstd::empty_type` rather than a bespoke type.

## Include hygiene

`std::size_t` was reaching the utility test through `<xstd/utility.hpp>`, and `is_specialization_of_v` was reaching the concepts test through `<xstd/concepts.hpp>`. Both now included directly, along with several stale include comments that had fallen behind the names actually used.

## Verification

clang-tidy 22.1.8 — the version CI runs — over the four header translation units and the four test sources, full check set plus a separate `clang-analyzer-*` pass: clean. clang-format clean across `include` and `test`; actionlint clean on the workflows. All four test translation units compile under clang `-Weverything -Werror` and gcc's warning set.